### PR TITLE
공통 예외 처리 구조 구현

### DIFF
--- a/src/main/java/com/trekker/global/config/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trekker/global/config/exception/GlobalExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.trekker.global.config.exception;
+
+import com.trekker.global.config.exception.custom.BusinessException;
+import com.trekker.global.config.exception.dto.ErrorResDto;
+import com.trekker.global.config.exception.enums.ErrorCode;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResDto> handleBusinessException(BusinessException e) {
+
+        String errorMessage = formatErrorMessage(e.getInvalidValue(), e.getFieldName(), e.getMessage());
+        logError(e, errorMessage);
+
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                .body(ErrorResDto.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResDto> handleBindException(BindException e) {
+
+        String errorMessage = formatErrorMessage(e);
+        logError(e, errorMessage);
+
+        return ResponseEntity.badRequest()
+                .body(ErrorResDto.of(ErrorCode.BAD_REQUEST));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResDto> handleException(Exception e) {
+
+        logError(e, "[EXCEPTION]  " + e.getClass());
+
+        return ResponseEntity.internalServerError()
+                .body(ErrorResDto.of(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    private void logError(Exception e, String errorMessage) {
+        log.error(errorMessage);
+        log.error("[EXCEPTION]  ERROR   -->   ", e);
+    }
+
+
+    private String formatErrorMessage(BindException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        return bindingResult.getFieldErrors().stream()
+                .map(fieldError ->
+                        formatErrorMessage(
+                                String.valueOf(fieldError.getRejectedValue()), // 값
+                                fieldError.getField(), // 필드명
+                                fieldError.getDefaultMessage() // 오류 메시지
+                        )
+                )
+                .collect(Collectors.joining(", "));
+    }
+
+    private String formatErrorMessage(String invalidValue, String errorField, String errorMessage) {
+        return String.format("[EXCEPTION]  ERROR_MESSAGE -->  [%s] %s: %s", invalidValue, errorField, errorMessage);
+    }
+}

--- a/src/main/java/com/trekker/global/config/exception/custom/BusinessException.java
+++ b/src/main/java/com/trekker/global/config/exception/custom/BusinessException.java
@@ -1,0 +1,40 @@
+package com.trekker.global.config.exception.custom;
+
+import com.trekker.global.config.exception.enums.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    //오류 발생 부분의 값. 명확하게 없으면 Null.
+    private final String invalidValue;
+    //오류 필드명.
+    private final String fieldName;
+    //오류 코드
+    private final ErrorCode errorCode;
+
+    /**
+     * 비지니스 에러를 ErroCode Enum으로 생성
+     *
+     * @param invalidValue 오류 발생 부분의 값
+     * @param fieldName    오류 필드 명
+     * @param errorCode    오류 상태코드와 메시지가 담긴 Enum
+     */
+    public BusinessException(Object invalidValue, String fieldName, ErrorCode errorCode) {
+
+        super(errorCode.getMessage());
+
+        this.invalidValue = invalidValue != null ? invalidValue.toString() : null;
+        this.fieldName = fieldName;
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+
+        super(errorCode.getMessage());
+
+        this.invalidValue = null;
+        this.fieldName = null;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/trekker/global/config/exception/dto/ErrorResDto.java
+++ b/src/main/java/com/trekker/global/config/exception/dto/ErrorResDto.java
@@ -1,0 +1,18 @@
+package com.trekker.global.config.exception.dto;
+
+import com.trekker.global.config.exception.enums.ErrorCode;
+import lombok.Builder;
+
+@Builder
+public record ErrorResDto(
+        Integer status,
+        String message
+) {
+
+    public static ErrorResDto of(ErrorCode errorCode) {
+        return ErrorResDto.builder()
+                .status(errorCode.getHttpStatus().value())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/trekker/global/config/exception/enums/ErrorCode.java
+++ b/src/main/java/com/trekker/global/config/exception/enums/ErrorCode.java
@@ -1,0 +1,19 @@
+package com.trekker.global.config.exception.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    //GLOBAL
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류")
+    ;
+
+    //오류 상태코드
+    private final HttpStatus httpStatus;
+    //오류 메시지
+    private final String message;
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #4

## 📝 Description

다음과 같이 공통 예외 처리를 구현하였습니다.

ErrorCode로 원하는 예외 메시지 및 상태 코드를 Enum으로 쉽게 관리하여, 추가 및 수정에 용이하게 구현하였습니다.
BusinessException로 로직상 예외를 발생시켜야할 때, 사용하는 언체크 예외를 구현하였습니다.

추후 예외를 발생 시킬려면
ErrorCode에 상태코드 및 오류 메시지를 도메인_상태코드명으로 만든 , 값,필드,ErrorCode로 예외를 발생시킵니다.

ex) new BusinessException(recruitId, "recruitId", ErrorCode.RECRUIT_NOT_FOUND)

일단 임시로 log를 찍게 하였으며, 추후 로그 파일을 따로 만들어 관리할 예정입니다.

## ⭐️ Review
