### PR TITLE
소셜 로그인 및 로그아웃/회원 탈퇴 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+security.env
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -36,6 +37,15 @@ dependencies {
 
     //p6spy 설치
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
+
+    // OAuth2 설치
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // JWT 설치
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
@@ -8,10 +8,20 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("select m from Member m join fetch m.socialProvider s where m.email =:email")
+    @Query("""
+            SELECT m 
+            FROM Member m 
+            JOIN FETCH m.socialProvider s 
+            WHERE m.email =:email 
+            """)
     Optional<Member> findByEmail(@Param("email") String email);
 
-    @Query("select m from Member m join fetch m.socialProvider s where s.provider =:provider and s.providerId =:providerId")
+    @Query("""
+            SELECT m 
+            FROM Member m 
+            JOIN FETCH m.socialProvider s 
+            WHERE s.provider =:provider AND s.providerId =:providerId
+            """)
     Optional<Member> findByProviderAndProviderId(@Param("provider") String provider,
             @Param("providerId") String providerId);
 }

--- a/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
@@ -1,8 +1,14 @@
 package com.trekker.domain.member.dao;
 
 import com.trekker.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    @Query("select m from Member m join fetch m.socialProvider s where s.provider =:provider and s.providerId =:providerId")
+    Optional<Member> findByProviderAndProviderId(@Param("provider") String provider,
+            @Param("providerId") String providerId);
 }

--- a/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.trekker.domain.member.dao;
+
+import com.trekker.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    @Query("select m from Member m join fetch m.socialProvider s where m.email =:email")
+    Optional<Member> findByEmail(@Param("email") String email);
+
     @Query("select m from Member m join fetch m.socialProvider s where s.provider =:provider and s.providerId =:providerId")
     Optional<Member> findByProviderAndProviderId(@Param("provider") String provider,
             @Param("providerId") String providerId);

--- a/src/main/java/com/trekker/domain/member/entity/Member.java
+++ b/src/main/java/com/trekker/domain/member/entity/Member.java
@@ -1,20 +1,16 @@
 package com.trekker.domain.member.entity;
 
 import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
-import com.trekker.global.entity.AuditBaseEntity;
 import com.trekker.global.entity.BaseEntity;
 import jakarta.persistence.*;
 
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import java.util.UUID;
 
 
 @Entity
@@ -43,5 +39,9 @@ public class Member extends BaseEntity {
     // 회원의 이름
     @Column(name = "name", length = MAX_NAME_LENGTH)
     private String name;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "social_provider_id")
+    private SocialProvider socialProvider;
 
 }

--- a/src/main/java/com/trekker/domain/member/entity/Member.java
+++ b/src/main/java/com/trekker/domain/member/entity/Member.java
@@ -7,7 +7,6 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import com.trekker.global.entity.BaseEntity;
 import jakarta.persistence.*;
 
-import javax.lang.model.element.Name;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/trekker/domain/member/entity/Member.java
+++ b/src/main/java/com/trekker/domain/member/entity/Member.java
@@ -1,0 +1,47 @@
+package com.trekker.domain.member.entity;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.trekker.global.entity.AuditBaseEntity;
+import com.trekker.global.entity.BaseEntity;
+import jakarta.persistence.*;
+
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.UUID;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "members")
+public class Member extends BaseEntity {
+
+    public static final int MAX_EMAIL_LENGTH = 256;
+    public static final int MAX_NAME_LENGTH = 10;
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "member_id", nullable = false)
+    private Long id;
+
+    // 계정의 아이디
+    @Column(name = "email", nullable = false, length = MAX_EMAIL_LENGTH)
+    private String email;
+
+    //권한
+    @Enumerated(STRING)
+    @Column(name = "role", nullable = false)
+    private Role role;
+
+    // 회원의 이름
+    @Column(name = "name", length = MAX_NAME_LENGTH)
+    private String name;
+
+}

--- a/src/main/java/com/trekker/domain/member/entity/Member.java
+++ b/src/main/java/com/trekker/domain/member/entity/Member.java
@@ -7,10 +7,11 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import com.trekker.global.entity.BaseEntity;
 import jakarta.persistence.*;
 
+import javax.lang.model.element.Name;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 
 
 @Entity
@@ -40,8 +41,27 @@ public class Member extends BaseEntity {
     @Column(name = "name", length = MAX_NAME_LENGTH)
     private String name;
 
-    @OneToOne(fetch = LAZY)
+    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "social_provider_id")
     private SocialProvider socialProvider;
+
+    @Builder
+    public Member(Long id, String email, Role role, String name, SocialProvider socialProvider) {
+        this.id = id;
+        this.email = email;
+        this.role = role;
+        this.name = name;
+        this.socialProvider = socialProvider;
+    }
+
+    public static Member toMember(String email, Role role, String provider, String providerId) {
+        SocialProvider socialProvider = SocialProvider.toSocialProvider(provider, providerId);
+
+        return Member.builder()
+                .email(email)
+                .role(role)
+                .socialProvider(socialProvider)
+                .build();
+    }
 
 }

--- a/src/main/java/com/trekker/domain/member/entity/Member.java
+++ b/src/main/java/com/trekker/domain/member/entity/Member.java
@@ -40,7 +40,7 @@ public class Member extends BaseEntity {
     @Column(name = "name", length = MAX_NAME_LENGTH)
     private String name;
 
-    @OneToOne(fetch = LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = LAZY, cascade = CascadeType.PERSIST, orphanRemoval = true)
     @JoinColumn(name = "social_provider_id")
     private SocialProvider socialProvider;
 

--- a/src/main/java/com/trekker/domain/member/entity/Role.java
+++ b/src/main/java/com/trekker/domain/member/entity/Role.java
@@ -1,0 +1,9 @@
+package com.trekker.domain.member.entity;
+
+/**
+ * 사용자 권한
+ */
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/trekker/domain/member/entity/SocialProvider.java
+++ b/src/main/java/com/trekker/domain/member/entity/SocialProvider.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,4 +31,17 @@ public class SocialProvider {
     @Column(name = "provider_id", unique = true)
     private String providerId;
 
+    @Builder
+    public SocialProvider(Long id, String provider, String providerId) {
+        this.id = id;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+
+    public static SocialProvider toSocialProvider(String provider, String providerId) {
+        return SocialProvider.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .build();
+    }
 }

--- a/src/main/java/com/trekker/domain/member/entity/SocialProvider.java
+++ b/src/main/java/com/trekker/domain/member/entity/SocialProvider.java
@@ -1,0 +1,33 @@
+package com.trekker.domain.member.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "social_providers")
+public class SocialProvider {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "social_provider_id", nullable = false)
+    private Long id;
+
+    // 소셜 로그인 제공자 정보 (예: kakao, naver 등)
+    @Column(name = "provider")
+    private String provider;
+
+    // 소셜 로그인 제공자의 고유 Id
+    @Column(name = "provider_id", unique = true)
+    private String providerId;
+
+}

--- a/src/main/java/com/trekker/global/auth/api/AuthController.java
+++ b/src/main/java/com/trekker/global/auth/api/AuthController.java
@@ -1,0 +1,67 @@
+package com.trekker.global.auth.api;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import com.trekker.global.auth.application.AuthService;
+import com.trekker.global.auth.dto.req.RefreshTokenReqDto;
+import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.config.security.annotation.LoginMember;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @RequestHeader(AUTHORIZATION_HEADER) String accessToken
+    ) {
+        String token = resolveToken(accessToken);
+        authService.logout(token);
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<Void> deleteAccount(
+            @LoginMember String email
+    ) {
+        authService.deleteAccount(email);
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResDto> refreshAccessToken(
+            @RequestBody RefreshTokenReqDto refreshTokenRequestDto
+    ) {
+        AuthResDto authResponseDto = authService.refreshAccessToken(
+                refreshTokenRequestDto.refreshToken());
+        return ResponseEntity.ok(authResponseDto);
+    }
+
+    /**
+     * 임시 토큰을 검증하고 최종 액세스 및 리프레시 토큰 발급
+     */
+    @GetMapping("/issue-final-token")
+    public ResponseEntity<?> issueFinalTokens(
+            @NotNull @RequestParam("tempToken") String tempToken
+    ) {
+        AuthResDto authResponse = authService.retrieveAuthResponse(tempToken);
+
+        return ResponseEntity.ok(authResponse);
+    }
+
+    private String resolveToken(String accessToken) {
+        if (accessToken.startsWith(BEARER_PREFIX)) {
+            return accessToken.substring(BEARER_PREFIX.length());
+        }
+        return accessToken;
+    }
+}

--- a/src/main/java/com/trekker/global/auth/api/AuthController.java
+++ b/src/main/java/com/trekker/global/auth/api/AuthController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import com.trekker.global.auth.application.AuthService;
 import com.trekker.global.auth.dto.req.RefreshTokenReqDto;
 import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.auth.dto.res.RefreshTokenResDto;
 import com.trekker.global.config.security.annotation.LoginMember;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -37,13 +38,23 @@ public class AuthController {
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/access/refresh")
     public ResponseEntity<AuthResDto> refreshAccessToken(
             @RequestBody RefreshTokenReqDto refreshTokenRequestDto
     ) {
         AuthResDto authResponseDto = authService.refreshAccessToken(
                 refreshTokenRequestDto.refreshToken());
         return ResponseEntity.ok(authResponseDto);
+    }
+
+    @PostMapping("/refresh/reissue")
+    public ResponseEntity<RefreshTokenResDto> reissueRefreshToken(
+            @RequestBody RefreshTokenReqDto refreshTokenRequestDto
+    ) {
+        RefreshTokenResDto refreshTokenResDto = authService.reissueRefreshToken(
+                refreshTokenRequestDto.refreshToken());
+
+        return ResponseEntity.ok(refreshTokenResDto);
     }
 
     /**

--- a/src/main/java/com/trekker/global/auth/application/AuthService.java
+++ b/src/main/java/com/trekker/global/auth/application/AuthService.java
@@ -73,6 +73,6 @@ public class AuthService {
         unlinkService.unlink(member);
 
         // 회원 삭제
-        memberRepository.delete(member);
+        member.markAsDeleted();
     }
 }

--- a/src/main/java/com/trekker/global/auth/application/AuthService.java
+++ b/src/main/java/com/trekker/global/auth/application/AuthService.java
@@ -3,6 +3,7 @@ package com.trekker.global.auth.application;
 import com.trekker.domain.member.dao.MemberRepository;
 import com.trekker.domain.member.entity.Member;
 import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.auth.dto.res.RefreshTokenResDto;
 import com.trekker.global.config.redis.dao.RedisRepository;
 import com.trekker.global.config.security.TokenProvider;
 import com.trekker.global.exception.custom.BusinessException;
@@ -42,6 +43,22 @@ public class AuthService {
         // JwtTokenProvider 에서 Refresh 토큰 유효성 검사 및 Access 토큰 재발급
         try {
             return tokenProvider.refreshAccessToken(refreshToken);
+        } catch (BusinessException e) {
+            throw new BusinessException(refreshToken, "refreshToken",
+                    ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * Refresh 토큰 만료시 Refresh 토큰 갱신
+     *
+     * @param refreshToken 클라이언트로부터 전달받은 기존 Refresh 토큰
+     * @return RefreshTokenResDto 새로 생성된 Refresh 토큰
+     */
+    public RefreshTokenResDto reissueRefreshToken(String refreshToken) {
+        // JwtTokenProvider 에서 Refresh 토큰 유효성 검사 및 Access 토큰 재발급
+        try {
+            return tokenProvider.reissueRefreshToken(refreshToken);
         } catch (BusinessException e) {
             throw new BusinessException(refreshToken, "refreshToken",
                     ErrorCode.INVALID_REFRESH_TOKEN);

--- a/src/main/java/com/trekker/global/auth/application/AuthService.java
+++ b/src/main/java/com/trekker/global/auth/application/AuthService.java
@@ -1,0 +1,78 @@
+package com.trekker.global.auth.application;
+
+import com.trekker.domain.member.dao.MemberRepository;
+import com.trekker.domain.member.entity.Member;
+import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.config.security.TokenProvider;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.enums.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+    private final RedisRepository redisRepository;
+    private final UnlinkService unlinkService;
+
+
+    @Transactional
+    public void logout(String jwtToken) {
+        long accessTokenExpiration = tokenProvider.getExpiration(jwtToken);
+        String userId = tokenProvider.getUserIdFromToken(jwtToken);
+
+        redisRepository.logoutTokens(jwtToken, accessTokenExpiration, userId);
+    }
+
+    /**
+     * Refresh 토큰을 이용한 Access 토큰 갱신
+     *
+     * @param refreshToken 클라이언트로부터 전달받은 Refresh 토큰
+     * @return AuthResponseDto 새로 생성된 Access 토큰과 기존의 Refresh 토큰
+     */
+    public AuthResDto refreshAccessToken(String refreshToken) {
+        // JwtTokenProvider 에서 Refresh 토큰 유효성 검사 및 Access 토큰 재발급
+        try {
+            return tokenProvider.refreshAccessToken(refreshToken);
+        } catch (BusinessException e) {
+            throw new BusinessException(refreshToken, "refreshToken",
+                    ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * 임시 토큰을 사용하여 Redis에서 인증 응답 데이터를 조회합니다.
+     *
+     * @param tempToken 임시 토큰 (프론트엔드에서 받은 tempToken)
+     * @return AuthResponseDto 인증에 필요한 Access, Refresh 토큰 조회된 데이터가 없을 경우 null을 반환합니다.
+     */
+    public AuthResDto retrieveAuthResponse(String tempToken) {
+        return redisRepository.retrieveAuthResponse(tempToken);
+    }
+
+    /**
+     * 회원 계정으로 회원을 조회하고, 삭제합니다. 삭제하면서 연결된 소셜 계정과 연결을 끊습니다.
+     *
+     * @param email 사용자 계정
+     */
+    @Transactional
+    public void deleteAccount(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(
+                        () -> new BusinessException(email, "email", ErrorCode.MEMBER_NOT_FOUND));
+
+        // 소셜 언링크 (연결 끊기)
+        unlinkService.unlink(member);
+
+        // 회원 삭제
+        memberRepository.delete(member);
+    }
+}

--- a/src/main/java/com/trekker/global/auth/application/UnlinkService.java
+++ b/src/main/java/com/trekker/global/auth/application/UnlinkService.java
@@ -1,0 +1,108 @@
+package com.trekker.global.auth.application;
+
+import com.trekker.domain.member.entity.Member;
+import com.trekker.domain.member.entity.SocialProvider;
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.enums.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UnlinkService {
+
+    private final RestTemplate restTemplate;
+    private final RedisRepository redisRepository;
+
+    @Value("${kakao.admin-key}")
+    private String kakaoAdminKey;
+
+    private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+    private static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+
+    /**
+     * 소셜 계정 연결 해제
+     *
+     * @param member 연결 해제할 회원
+     */
+    public void unlink(Member member) {
+        SocialProvider socialProvider = member.getSocialProvider();
+
+        try {
+            switch (socialProvider.getProvider().toLowerCase()) {
+                case "kakao":
+                    unlinkKakao(socialProvider.getProviderId());
+                    break;
+                case "google":
+                    unlinkGoogle(member.getEmail());
+                    break;
+                default:
+                    throw new BusinessException(ErrorCode.UNSUPPORTED_SOCIAL_PROVIDER);
+            }
+        } catch (BusinessException e) {
+            log.error("소셜 연결 해제 실패: 사용자 ID = {}, Error = {}", socialProvider.getProviderId(),
+                    e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * 카카오 연결 해제
+     *
+     * @param providerId 소셜 제공자의 고유 ID
+     */
+    private void unlinkKakao(String providerId) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("target_id_type", "user_id");
+        body.add("target_id", providerId);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            restTemplate.postForEntity(KAKAO_UNLINK_URL, request, String.class);
+            log.info("카카오 연결 끊기 성공: 사용자 ID = {}", providerId);
+        } catch (Exception e) {
+            log.error("카카오 연결 끊기 실패: 사용자 ID = {}", providerId, e);
+            throw new BusinessException(providerId, "providerId", ErrorCode.SOCIAL_UNLINK_FAILED);
+        }
+    }
+
+    /**
+     * 구글 연결 해제
+     *
+     * @param email 사용자 이메일
+     */
+    private void unlinkGoogle(String email) {
+        String refreshToken = redisRepository.fetchAndDeleteSocialRefreshToken(email);
+
+        if (refreshToken == null) {
+            log.error("구글 연결 끊기 실패: Refresh Token이 없습니다.");
+            throw new BusinessException(email, "refreshToken", ErrorCode.SOCIAL_UNLINK_FAILED);
+        }
+
+        String url = GOOGLE_REVOKE_URL + "?token=" + refreshToken;
+
+        try {
+            restTemplate.postForEntity(url, null, String.class);
+            log.info("구글 연결 끊기 성공: 사용자 이메일 = {}", email);
+        } catch (Exception e) {
+            log.error("구글 연결 끊기 실패: Refresh Token = {}", refreshToken, e);
+            throw new BusinessException(refreshToken, "refreshToken",
+                    ErrorCode.SOCIAL_UNLINK_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/trekker/global/auth/application/UnlinkService.java
+++ b/src/main/java/com/trekker/global/auth/application/UnlinkService.java
@@ -25,10 +25,11 @@ public class UnlinkService {
     private final RedisRepository redisRepository;
 
     @Value("${kakao.admin-key}")
-    private String kakaoAdminKey;
-
-    private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
-    private static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+    private String KAKAO_ADMIN_KEY;
+    @Value("${kakao.unlink-url}")
+    private String KAKAO_UNLINK_URL;
+    @Value("${google.unlink-url}")
+    private String GOOGLE_UNLINK_URL;
 
     /**
      * 소셜 계정 연결 해제
@@ -63,7 +64,7 @@ public class UnlinkService {
      */
     private void unlinkKakao(String providerId) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+        headers.set("Authorization", "KakaoAK " + KAKAO_ADMIN_KEY);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
@@ -94,7 +95,7 @@ public class UnlinkService {
             throw new BusinessException(email, "refreshToken", ErrorCode.SOCIAL_UNLINK_FAILED);
         }
 
-        String url = GOOGLE_REVOKE_URL + "?token=" + refreshToken;
+        String url = GOOGLE_UNLINK_URL + "?token=" + refreshToken;
 
         try {
             restTemplate.postForEntity(url, null, String.class);

--- a/src/main/java/com/trekker/global/auth/custom/CustomUserDetails.java
+++ b/src/main/java/com/trekker/global/auth/custom/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package com.trekker.global.auth.custom;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Getter
+@Builder
+public class CustomUserDetails implements OAuth2User {
+
+    private String email;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    /**
+     * 사용자의 권한 정보 반환
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+}

--- a/src/main/java/com/trekker/global/auth/custom/CustomUserDetailsService.java
+++ b/src/main/java/com/trekker/global/auth/custom/CustomUserDetailsService.java
@@ -1,0 +1,79 @@
+package com.trekker.global.auth.custom;
+
+import com.trekker.domain.member.dao.MemberRepository;
+import com.trekker.domain.member.entity.Member;
+import com.trekker.domain.member.entity.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService extends DefaultOAuth2UserService {
+
+    private static final String KAKAO = "kakao";
+    private static final String GOOGLE = "google";
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // 소셜 로그인 제공자 (ex: kakao, google, naver)
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        // 소셜 고유 ID 및 이메일 추출
+        String providerId = String.valueOf(
+                extractAttribute(oAuth2User, provider, isGoogleProvider(provider) ? "sub" : "id"));
+        String email = (String) extractAttribute(oAuth2User, provider, "email");
+
+        // provider와 providerId를 기준으로 사용자 조회
+        Member member = memberRepository.findByProviderAndProviderId(provider, providerId)
+                .orElseGet(() -> memberRepository.save(
+                        Member.toMember(email, Role.USER, provider, providerId)));
+
+        // UserDetails 생성 및 반환
+        return createUserDetails(member, oAuth2User.getAttributes());
+    }
+
+    private CustomUserDetails createUserDetails(Member member, Map<String, Object> attributes) {
+        return CustomUserDetails.builder()
+                .email(member.getEmail())
+                .authorities(Collections.singleton(
+                        new SimpleGrantedAuthority("ROLE_" + member.getRole().toString())))
+                .attributes(attributes) // OAuth2일 경우 속성 설정
+                .build();
+    }
+
+    /**
+     * 소셜 제공자별로 필요한 속성을 추출하는 메서드
+     */
+    private Object extractAttribute(OAuth2User oAuth2User, String provider, String attributeKey) {
+        return switch (provider.toLowerCase()) {
+            case KAKAO -> extractKakaoAttribute(oAuth2User, attributeKey);
+            case GOOGLE -> oAuth2User.getAttributes().get(attributeKey);
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인 제공자입니다: " + provider);
+        };
+    }
+
+    private Object extractKakaoAttribute(OAuth2User oAuth2User, String attributeKey) {
+        if ("email".equals(attributeKey)) {
+            Map<String, Object> kakaoAccount = (Map<String, Object>) oAuth2User.getAttributes()
+                    .get("kakao_account");
+            return kakaoAccount.get("email");
+        }
+        return oAuth2User.getAttributes().get("id");
+    }
+
+    private boolean isGoogleProvider(String provider) {
+        return GOOGLE.equals(provider);
+    }
+}

--- a/src/main/java/com/trekker/global/auth/dto/RefreshTokenInfoDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/RefreshTokenInfoDto.java
@@ -1,8 +1,6 @@
 package com.trekker.global.auth.dto;
 
-import lombok.Getter;
 
-@Getter
 public record RefreshTokenInfoDto(String userAccount, String refreshToken, String authorities) {
 
 }

--- a/src/main/java/com/trekker/global/auth/dto/RefreshTokenInfoDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/RefreshTokenInfoDto.java
@@ -1,0 +1,8 @@
+package com.trekker.global.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public record RefreshTokenInfoDto(String userAccount, String refreshToken, String authorities) {
+
+}

--- a/src/main/java/com/trekker/global/auth/dto/req/RefreshTokenReqDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/req/RefreshTokenReqDto.java
@@ -1,0 +1,5 @@
+package com.trekker.global.auth.dto.req;
+
+public record RefreshTokenReqDto(String refreshToken) {
+
+}

--- a/src/main/java/com/trekker/global/auth/dto/res/AuthResDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/res/AuthResDto.java
@@ -1,0 +1,5 @@
+package com.trekker.global.auth.dto.res;
+
+public record AuthResDto(String accessToken, String RefreshToken) {
+
+}

--- a/src/main/java/com/trekker/global/auth/dto/res/AuthResDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/res/AuthResDto.java
@@ -1,5 +1,5 @@
 package com.trekker.global.auth.dto.res;
 
-public record AuthResDto(String accessToken, String refreshToken) {
+public record AuthResDto(String accessToken, String refreshToken, boolean refreshTokenWillExpire) {
 
 }

--- a/src/main/java/com/trekker/global/auth/dto/res/AuthResDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/res/AuthResDto.java
@@ -1,5 +1,5 @@
 package com.trekker.global.auth.dto.res;
 
-public record AuthResDto(String accessToken, String RefreshToken) {
+public record AuthResDto(String accessToken, String refreshToken) {
 
 }

--- a/src/main/java/com/trekker/global/auth/dto/res/RefreshTokenResDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/res/RefreshTokenResDto.java
@@ -1,0 +1,5 @@
+package com.trekker.global.auth.dto.res;
+
+public record RefreshTokenResDto(String refreshToken) {
+
+}

--- a/src/main/java/com/trekker/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/trekker/global/config/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.trekker.global.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // 키를 문자열로 직렬화
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        // JSON 직렬화기 추가 설정
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // 해시 키를 문자열로 직렬화
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // 해시 값을 JSON 형식으로 직렬화
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
+++ b/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
@@ -1,0 +1,171 @@
+package com.trekker.global.config.redis.dao;
+
+import com.trekker.global.auth.dto.RefreshTokenInfoDto;
+import com.trekker.global.auth.dto.res.AuthResDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final int TEMP_TOKEN_EXPIRATION = 300;
+    private static final int SOCIAL_REFRESH_TOKEN_EXPIRATION = 3650;
+    private static final String SOCIAL_TOKEN_REDIS_KEY = "social:refreshToken";
+
+    /**
+     * Refresh 토큰과 사용자 정보를 Redis에 저장
+     */
+    public void storeRefreshToken(RefreshTokenInfoDto tokenData) {
+        try {
+            HashOperations<String, Object, Object> hashOperations = redisTemplate.opsForHash();
+
+            // RefreshTokenData 에서 데이터를 맵 형태로 변환
+            HashMap<String, Object> tokenDataMap = createTokenDataMap(tokenData);
+
+            // 해시로 데이터 저장
+            hashOperations.putAll(tokenData.getUserAccount(), tokenDataMap);
+
+            // 만료 시간 설정 (1주일)
+            boolean isExpireSet = Boolean.TRUE.equals(
+                    redisTemplate.expire(tokenData.getUserAccount(), 7, TimeUnit.DAYS));
+            if (!isExpireSet) {
+                log.warn("TTL 설정에 실패했습니다. userAccount: {}", tokenData.getUserAccount());
+            }
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis 연결 실패", e);
+        } catch (RedisSystemException e) {
+            log.error("Redis 시스템 예외 발생", e);
+        } catch (Exception e) {
+            log.error("Redis에 데이터를 저장 중 예기치 못한 오류 발생", e);
+        }
+    }
+
+    /**
+     * Refresh 토큰이 유효한지 확인
+     */
+    public boolean isValidRefreshToken(String userAccount, String refreshToken) {
+        try {
+            String storedRefreshToken = (String) redisTemplate.opsForHash()
+                    .get(userAccount, "refreshToken");
+            return storedRefreshToken != null && storedRefreshToken.equals(refreshToken);
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis 연결 실패", e);
+            return false;
+        } catch (Exception e) {
+            log.error("Refresh 토큰 검증 중 예기치 못한 오류 발생", e);
+            return false;
+        }
+    }
+
+    /**
+     * 로그아웃 시 액세스 토큰과 리프레시 토큰을 블랙리스트에 추가하는 메서드
+     */
+    public void logoutTokens(String jwtToken, long accessTokenExpiration, String userId) {
+        try {
+            // 1. 액세스 토큰 블랙리스트 등록
+            redisTemplate.opsForValue().set(
+                    jwtToken,
+                    "blacklisted",
+                    accessTokenExpiration,
+                    TimeUnit.MILLISECONDS);
+
+            // 2. 리프레시 토큰을 업데이트하여 만료 처리
+            redisTemplate.delete(userId);
+
+        } catch (Exception e) {
+            log.error("토큰 블랙리스트 등록 중 오류 발생", e);
+            throw new RuntimeException("로그아웃 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * Refresh 토큰 저장을 위한 데이터 맵 생성
+     */
+    private HashMap<String, Object> createTokenDataMap(RefreshTokenInfoDto tokenData) {
+        HashMap<String, Object> tokenDataMap = new HashMap<>();
+        tokenDataMap.put("refreshToken", tokenData.getRefreshToken());
+        tokenDataMap.put("authorities", tokenData.getAuthorities());
+        return tokenDataMap;
+    }
+
+    /**
+     * Redis에서 사용자 권한 정보 가져오기
+     */
+    public String getAuthorities(String userAccount) {
+        try {
+            // Redis에서 userAccount에 해당하는 "authorities" 필드를 가져옴
+            return (String) redisTemplate.opsForHash().get(userAccount, "authorities");
+        } catch (RedisConnectionFailureException e) {
+            log.error("Redis 연결 실패", e);
+            return null;
+        } catch (Exception e) {
+            log.error("사용자 권한 정보를 가져오는 중 예기치 못한 오류 발생", e);
+            return null;
+        }
+    }
+
+    public String storeAuthResponseWithTempToken(AuthResDto authResDto) {
+        String tempToken = UUID.randomUUID().toString();
+        try {
+            redisTemplate.opsForValue()
+                    .set(tempToken, authResDto, TEMP_TOKEN_EXPIRATION, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("Redis에 임시 토큰 저장 중 오류 발생", e);
+            throw new RuntimeException("임시 토큰 생성 중 오류가 발생했습니다.", e);
+        }
+        return tempToken;
+    }
+
+    // 임시 토큰으로 AuthResponseDto를 조회
+    public AuthResDto retrieveAuthResponse(String tempToken) {
+        try {
+            AuthResDto authResponse = (AuthResDto) redisTemplate.opsForValue()
+                    .get(tempToken);
+            redisTemplate.delete(tempToken);// 임시 토큰 만료 처리
+            return authResponse;
+        } catch (Exception e) {
+            log.error("Redis에서 AuthResponse 조회 중 오류 발생", e);
+            throw new RuntimeException("임시 토큰 검증 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * google 계정일 경우 회원 탈퇴를 위한 리프래시 토큰을 저장하는 메소드
+     */
+    public void storeSocialRefreshTokenWithExtendedTTL(String userAccount, String refreshToken) {
+        try {
+            String redisKey = SOCIAL_TOKEN_REDIS_KEY + userAccount;
+            redisTemplate.opsForValue()
+                    .set(redisKey, refreshToken, SOCIAL_REFRESH_TOKEN_EXPIRATION, TimeUnit.DAYS);
+            log.info("소셜 Refresh Token 저장 (TTL 10년): key={}, refreshToken={}", redisKey,
+                    refreshToken);
+        } catch (Exception e) {
+            log.error("Redis에 소셜 Refresh Token 저장 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * google 계정일 경우 회원 탈퇴를 위한 리프래시 토큰을 조회하고 Redis에서 삭제하는 메소드
+     */
+    public String fetchAndDeleteSocialRefreshToken(String userAccount) {
+        String redisKey = SOCIAL_TOKEN_REDIS_KEY + userAccount;
+        String refreshToken = (String) redisTemplate.opsForValue().get(redisKey);
+        if (refreshToken != null) {
+            redisTemplate.delete(redisKey); // 조회 후 삭제
+        }
+        return refreshToken;
+    }
+
+}

--- a/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
+++ b/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
@@ -162,9 +162,7 @@ public class RedisRepository {
     public String fetchAndDeleteSocialRefreshToken(String userAccount) {
         String redisKey = SOCIAL_TOKEN_REDIS_KEY + userAccount;
         String refreshToken = (String) redisTemplate.opsForValue().get(redisKey);
-        if (refreshToken != null) {
-            redisTemplate.delete(redisKey); // 조회 후 삭제
-        }
+        redisTemplate.delete(redisKey); // 조회 후 삭제
         return refreshToken;
     }
 

--- a/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
+++ b/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
@@ -27,6 +27,9 @@ public class RedisRepository {
      */
     public void storeRefreshToken(RefreshTokenInfoDto tokenData) {
         try {
+            // 기존 데이터 삭제
+            redisTemplate.delete(tokenData.userAccount());
+
             HashOperations<String, Object, Object> hashOperations = redisTemplate.opsForHash();
             hashOperations.putAll(tokenData.userAccount(), createTokenDataMap(tokenData));
             redisTemplate.expire(tokenData.userAccount(), 7, TimeUnit.DAYS);

--- a/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
+++ b/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
@@ -35,13 +35,13 @@ public class RedisRepository {
             HashMap<String, Object> tokenDataMap = createTokenDataMap(tokenData);
 
             // 해시로 데이터 저장
-            hashOperations.putAll(tokenData.getUserAccount(), tokenDataMap);
+            hashOperations.putAll(tokenData.userAccount(), tokenDataMap);
 
             // 만료 시간 설정 (1주일)
             boolean isExpireSet = Boolean.TRUE.equals(
-                    redisTemplate.expire(tokenData.getUserAccount(), 7, TimeUnit.DAYS));
+                    redisTemplate.expire(tokenData.userAccount(), 7, TimeUnit.DAYS));
             if (!isExpireSet) {
-                log.warn("TTL 설정에 실패했습니다. userAccount: {}", tokenData.getUserAccount());
+                log.warn("TTL 설정에 실패했습니다. userAccount: {}", tokenData.userAccount());
             }
         } catch (RedisConnectionFailureException e) {
             log.error("Redis 연결 실패", e);
@@ -95,8 +95,8 @@ public class RedisRepository {
      */
     private HashMap<String, Object> createTokenDataMap(RefreshTokenInfoDto tokenData) {
         HashMap<String, Object> tokenDataMap = new HashMap<>();
-        tokenDataMap.put("refreshToken", tokenData.getRefreshToken());
-        tokenDataMap.put("authorities", tokenData.getAuthorities());
+        tokenDataMap.put("refreshToken", tokenData.refreshToken());
+        tokenDataMap.put("authorities", tokenData.authorities());
         return tokenDataMap;
     }
 

--- a/src/main/java/com/trekker/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/trekker/global/config/security/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.trekker.global.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증을 비활성화 (JWT 방식을 사용하기 위해서)
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호를 비활성화 (JWT 인증은 세션이 아닌 토큰 기반이라 필요 없음)
+                .cors(cors -> cors.configurationSource(
+                        corsConfigurationSource())) // CORS 설정을 활성화하여 corsConfigurationSource()에서 상세 설정을 정의
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                        STATELESS)) // 세션 정책을 STATELESS로 설정하여 서버에서 세션을 생성하지 않음
+                .build();
+
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(
+                Arrays.asList("HEAD", "GET", "POST", "DELETE", "PATCH")); // 모든 HTTP 메서드 허용
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true); // 쿠키를 포함한 요청 허용
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 위의 CORS 설정 적용
+        return source;
+    }
+}

--- a/src/main/java/com/trekker/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/trekker/global/config/security/SecurityConfig.java
@@ -9,8 +9,6 @@ import com.trekker.global.config.security.handler.CustomLoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -37,16 +35,6 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
-    /**
-     * AuthenticationManager 빈 등록
-     */
-    @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(
-                AuthenticationManagerBuilder.class);
-        return authenticationManagerBuilder.build();
-    }
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
@@ -59,8 +47,9 @@ public class SecurityConfig {
                         STATELESS)) // 세션 정책을 STATELESS로 설정하여 서버에서 세션을 생성하지 않음
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
-                                .requestMatchers("/api/v1/auth/refresh").permitAll()
-                                .requestMatchers("/login/oauth2/**", "/oauth2/**").permitAll()
+                                .requestMatchers("/api/v1/auth/refresh",
+                                        "/api/v1/auth/issue-final-token"
+                                        , "/login/oauth2/**", "/oauth2/**").permitAll()
                                 .anyRequest().authenticated())
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/com/trekker/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/trekker/global/config/security/SecurityConfig.java
@@ -49,7 +49,8 @@ public class SecurityConfig {
                         authorizationManagerRequestMatcherRegistry
                                 .requestMatchers("/api/v1/auth/refresh",
                                         "/api/v1/auth/issue-final-token"
-                                        , "/login/oauth2/**", "/oauth2/**").permitAll()
+                                        , "/login/oauth2/**", "/oauth2/**", "/error",
+                                        "/favicon.ico").permitAll()
                                 .anyRequest().authenticated())
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(customAuthenticationEntryPoint)

--- a/src/main/java/com/trekker/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/trekker/global/config/security/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                         STATELESS)) // 세션 정책을 STATELESS로 설정하여 서버에서 세션을 생성하지 않음
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
-                                .requestMatchers("/api/v1/auth/refresh",
+                                .requestMatchers("/api/v1/auth/access/refresh","/api/v1/auth/refresh/reissue",
                                         "/api/v1/auth/issue-final-token"
                                         , "/login/oauth2/**", "/oauth2/**", "/error",
                                         "/favicon.ico").permitAll()

--- a/src/main/java/com/trekker/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/trekker/global/config/security/SecurityConfig.java
@@ -1,12 +1,21 @@
 package com.trekker.global.config.security;
 
+import com.trekker.global.auth.custom.CustomUserDetailsService;
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.config.security.filter.JwtFilter;
+import com.trekker.global.config.security.handler.CustomAccessDeniedHandler;
+import com.trekker.global.config.security.handler.CustomAuthenticationEntryPoint;
+import com.trekker.global.config.security.handler.CustomLoginSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -21,17 +30,48 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final TokenProvider tokenProvider;
+    private final RedisRepository redisRepository;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final CustomLoginSuccessHandler loginSuccessHandler;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    /**
+     * AuthenticationManager 빈 등록
+     */
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder authenticationManagerBuilder = http.getSharedObject(
+                AuthenticationManagerBuilder.class);
+        return authenticationManagerBuilder.build();
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증을 비활성화 (JWT 방식을 사용하기 위해서)
+                .httpBasic(
+                        AbstractHttpConfigurer::disable) // HTTP Basic 인증을 비활성화 (JWT 방식을 사용하기 위해서)
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호를 비활성화 (JWT 인증은 세션이 아닌 토큰 기반이라 필요 없음)
                 .cors(cors -> cors.configurationSource(
                         corsConfigurationSource())) // CORS 설정을 활성화하여 corsConfigurationSource()에서 상세 설정을 정의
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
                         STATELESS)) // 세션 정책을 STATELESS로 설정하여 서버에서 세션을 생성하지 않음
+                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers("/api/v1/auth/refresh").permitAll()
+                                .requestMatchers("/login/oauth2/**", "/oauth2/**").permitAll()
+                                .anyRequest().authenticated())
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(
+                                userInfo -> userInfo.userService(customUserDetailsService))
+                        .successHandler(loginSuccessHandler))
+                .addFilterBefore(new JwtFilter(tokenProvider, redisRepository),
+                        UsernamePasswordAuthenticationFilter.class)
                 .build();
-
     }
 
     @Bean

--- a/src/main/java/com/trekker/global/config/security/TokenProvider.java
+++ b/src/main/java/com/trekker/global/config/security/TokenProvider.java
@@ -3,6 +3,7 @@ package com.trekker.global.config.security;
 import com.trekker.global.auth.custom.CustomUserDetails;
 import com.trekker.global.auth.dto.RefreshTokenInfoDto;
 import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.auth.dto.res.RefreshTokenResDto;
 import com.trekker.global.config.redis.dao.RedisRepository;
 import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
@@ -59,7 +60,7 @@ public class TokenProvider {
         // Redis에 Refresh 토큰 저장
         redisRepository.storeRefreshToken(refreshTokenInfoDto);
 
-        return new AuthResDto(accessToken, refreshToken);
+        return new AuthResDto(accessToken, refreshToken, false);
     }
 
     // 공통 토큰 생성 로직
@@ -99,11 +100,50 @@ public class TokenProvider {
         // 4. Redis에서 사용자 권한 정보 추출
         String authorities = redisRepository.getAuthorities(userId);
 
-        // 5. 새로운 Access 토큰 생성
+        // 5. Refresh 토큰의 남은 만료 시간 확인
+        long remainingTime = getExpiration(refreshToken);
+        // 남은 시간이 전체 만료시간의 30%보다 적은 경우, 만료 임박 상태로 간주
+        boolean refreshTokenWillExpire = remainingTime < (REFRESH_TOKEN_EXPIRATION * 0.3);
+
+        // 6. 새로운 Access 토큰 생성
         String newAccessToken = createToken(userId, authorities, ACCESS_TOKEN_EXPIRATION);
 
-        // 6. 새로운 AuthResponseDto 반환 (기존 Refresh 토큰 유지)
-        return new AuthResDto(newAccessToken, refreshToken);
+        // 7. 새로운 AuthResponseDto 반환 (기존 Refresh 토큰 유지)
+        return new AuthResDto(newAccessToken, refreshToken, refreshTokenWillExpire);
+    }
+
+    /**
+     * Refresh 토큰 갱신 로직
+     *
+     * @param currentRefreshToken 기존 Refresh 토큰
+     * @return 새로 생성된 Refresh 토큰
+     */
+    public RefreshTokenResDto reissueRefreshToken(String currentRefreshToken) {
+        // 1. 기존 Refresh 토큰 유효성 검사
+        validateToken(currentRefreshToken);
+
+        // 2. 사용자 ID 추출
+        String userId = getUserIdFromToken(currentRefreshToken);
+
+        // 3. Redis에서 기존 Refresh 토큰 유효성 검사
+        if (!redisRepository.isValidRefreshToken(userId, currentRefreshToken)) {
+            throw new BusinessException(currentRefreshToken, "refreshToken",
+                    ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 4. 새로운 Refresh 토큰 생성
+        String newRefreshToken = createToken(userId, null, REFRESH_TOKEN_EXPIRATION);
+
+        // 5. Redis에 새 Refresh 토큰 저장
+        RefreshTokenInfoDto refreshTokenInfoDto = new RefreshTokenInfoDto(
+                userId,
+                newRefreshToken,
+                redisRepository.getAuthorities(userId) // 사용자 권한 정보 가져오기
+        );
+        redisRepository.storeRefreshToken(refreshTokenInfoDto);
+
+        // 6. 새 Refresh 토큰 반환
+        return new RefreshTokenResDto(newRefreshToken);
     }
 
 

--- a/src/main/java/com/trekker/global/config/security/TokenProvider.java
+++ b/src/main/java/com/trekker/global/config/security/TokenProvider.java
@@ -1,0 +1,183 @@
+package com.trekker.global.config.security;
+
+import com.trekker.global.auth.custom.CustomUserDetails;
+import com.trekker.global.auth.dto.RefreshTokenInfoDto;
+import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.enums.ErrorCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class TokenProvider {
+
+    private final Key key;
+    private final RedisRepository redisRepository;
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 30; // 30분
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    @Autowired
+    public TokenProvider(@Value("${jwt.secret}") String secretKey,
+            RedisRepository redisRepository) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.redisRepository = redisRepository;
+    }
+
+    /**
+     * Authentication 객체로부터 Access 토큰, Refresh 토큰 생성 및 AuthResponse 반환
+     */
+    public AuthResDto createAuthResponse(Authentication authentication) {
+        String roles = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        String accessToken = createToken(authentication.getName(), roles, ACCESS_TOKEN_EXPIRATION);
+        String refreshToken = createToken(authentication.getName(), null, REFRESH_TOKEN_EXPIRATION);
+
+        // Redis에 Refresh 토큰 저장을 위해 RefreshTokenInfoDto 생성
+        RefreshTokenInfoDto refreshTokenInfoDto = new RefreshTokenInfoDto(
+                authentication.getName(),
+                refreshToken,
+                roles
+        );
+        // Redis에 Refresh 토큰 저장
+        redisRepository.storeRefreshToken(refreshTokenInfoDto);
+
+        return new AuthResDto(accessToken, refreshToken);
+    }
+
+    // 공통 토큰 생성 로직
+    private String createToken(String userId, String roles, long expiration) {
+        Claims claims = Jwts.claims().setSubject(userId);
+        if (roles != null) {
+            claims.put("roles", roles);
+        }
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Refresh 토큰을 이용한 Access 토큰 갱신
+     */
+    public AuthResDto refreshAccessToken(String refreshToken) {
+        // 1. 토큰 유효성 검사
+        validateToken(refreshToken);
+
+        // 2. 토큰에서 사용자 ID 추출
+        String userId = getUserIdFromToken(refreshToken);
+
+        // 3. Redis에서 Refresh 토큰 유효성 검사
+        if (!redisRepository.isValidRefreshToken(userId, refreshToken)) {
+            throw new BusinessException(refreshToken, "refreshToken",
+                    ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 4. Redis에서 사용자 권한 정보 추출
+        String authorities = redisRepository.getAuthorities(userId);
+
+        // 5. 새로운 Access 토큰 생성
+        String newAccessToken = createToken(userId, authorities, ACCESS_TOKEN_EXPIRATION);
+
+        // 6. 새로운 AuthResponseDto 반환 (기존 Refresh 토큰 유지)
+        return new AuthResDto(newAccessToken, refreshToken);
+    }
+
+
+    // 토큰에서 사용자 ID 추출
+    public String getUserIdFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    /**
+     * 토큰에서 사용자 정보 추출 후 Authentication 객체 생성
+     *
+     * @param token JWT 토큰
+     * @return Authentication 객체
+     */
+    public Authentication getAuthentication(String token) {
+        // 1. 토큰에서 사용자 정보 추출
+        Claims claims = parseClaims(token);
+        String email = claims.getSubject();
+        String roles = claims.get("roles", String.class);
+
+        // 2. 권한 정보 설정
+        Collection<GrantedAuthority> authorities = Arrays.stream(roles.split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // 3. CustomUserDetails 객체 생성
+        CustomUserDetails customUserDetails = CustomUserDetails.builder()
+                .email(email)
+                .authorities(authorities)
+                .build();
+
+        // 4. Authentication 객체 반환
+        return new UsernamePasswordAuthenticationToken(customUserDetails, token, authorities);
+    }
+
+    /**
+     * 토큰에서 만료 시간 가져오기
+     *
+     * @param token JWT 토큰
+     * @return 토큰의 남은 만료 시간 (밀리초)
+     */
+    public long getExpiration(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().getTime() - System.currentTimeMillis();
+    }
+
+    /**
+     * 토큰 검증
+     *
+     * @param token 검증할 토큰
+     * @return 올바르면 true, 올바르지 않으면 false
+     */
+    public void validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.debug("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.debug("만료된 JWT 토큰입니다.");
+            throw e; // 만료된 토큰은 그대로 던짐
+        } catch (UnsupportedJwtException e) {
+            log.debug("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.debug("JWT 토큰이 잘못되었습니다.");
+        }
+    }
+
+    // Claims 파싱
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}

--- a/src/main/java/com/trekker/global/config/security/annotation/LoginMember.java
+++ b/src/main/java/com/trekker/global/config/security/annotation/LoginMember.java
@@ -1,0 +1,19 @@
+package com.trekker.global.config.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+/**
+ * 인증된 사용자 정보를 가져오는 어노테이션
+ * 인증되지 않은 경우 예외를 발생시킴
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "T(com.trekker.global.config.security.annotation.LoginMemberUtil).getPrincipalOrThrow(#this)")
+public @interface LoginMember {
+
+    boolean required() default true;
+}

--- a/src/main/java/com/trekker/global/config/security/annotation/LoginMemberUtil.java
+++ b/src/main/java/com/trekker/global/config/security/annotation/LoginMemberUtil.java
@@ -1,0 +1,27 @@
+package com.trekker.global.config.security.annotation;
+
+import com.trekker.global.auth.custom.CustomUserDetails;
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * @LoginMember에서 사용되는 유틸리티 클래스
+ */
+public class LoginMemberUtil {
+
+    /**
+     * 인증된 Principal 객체를 반환하거나 예외를 발생
+     *
+     * @param principal 인증된 사용자 정보
+     * @return email 사용자 계정
+     * @throws AuthenticationException 인증되지 않은 경우
+     */
+    public static String  getPrincipalOrThrow(Object principal) {
+        if (principal instanceof CustomUserDetails) {
+            return ((CustomUserDetails) principal).getEmail(); // 인증된 사용자 반환
+        }
+
+        // 인증되지 않았거나 예상치 못한 객체 타입일 경우 예외 발생
+        throw new AuthenticationException("Authentication is required") {
+        };
+    }
+}

--- a/src/main/java/com/trekker/global/config/security/filter/JwtFilter.java
+++ b/src/main/java/com/trekker/global/config/security/filter/JwtFilter.java
@@ -1,0 +1,81 @@
+package com.trekker.global.config.security.filter;
+
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.config.security.TokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final TokenProvider tokenProvider;
+    private final RedisRepository redisRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        // 요청 헤더에서 JWT 토큰을 추출
+        String token = extractToken(request);
+
+        try {
+            // 토큰이 존재하면 검증을 진행
+            if (token != null) {
+                // JWT 토큰의 유효성을 검증
+                tokenProvider.validateToken(token);
+
+                // 토큰이 블랙리스트에 포함되어 있지 않은 경우
+                if (!isTokenBlacklisted(token)) {
+                    // 토큰에서 인증 정보를 가져와 SecurityContext에 설정
+                    Authentication authentication = tokenProvider.getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰 예외 발생 시 로그 기록
+            log.warn("만료된 토큰: {}", e.getMessage());
+        }
+
+        // 필터 체인의 다음 필터로 요청과 응답을 전달
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 요청 헤더에서 JWT 토큰을 추출하는 메서드
+     *
+     * @param request HTTP 요청
+     * @return 추출된 JWT 토큰 (없으면 null 반환)
+     */
+    private String extractToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        return (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) ?
+                bearerToken.substring(BEARER_PREFIX.length()) : null;
+    }
+
+    /**
+     * Redis 블랙리스트에서 토큰의 존재 여부를 확인하는 메서드
+     *
+     * @param token JWT 토큰
+     * @return 토큰이 블랙리스트에 있으면 true 반환
+     */
+    private boolean isTokenBlacklisted(String token) {
+        String userId = tokenProvider.getUserIdFromToken(token);
+        return Boolean.TRUE.equals(redisRepository.isValidRefreshToken(userId, token));
+    }
+
+}
+

--- a/src/main/java/com/trekker/global/config/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,45 @@
+package com.trekker.global.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trekker.global.exception.dto.ErrorResDto;
+import com.trekker.global.exception.enums.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 권한 예외 핸들러
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper mapper;
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException)
+            throws IOException {
+
+        log.warn("Access Denied: URI = {}, Method = {}, Message = {}",
+                request.getRequestURI(),
+                request.getMethod(),
+                accessDeniedException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResDto errorResponse = ErrorResDto.of(ErrorCode.ACCESS_DENIED_EXCEPTION);
+
+        response.getWriter().write(mapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/trekker/global/config/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.trekker.global.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trekker.global.exception.dto.ErrorResDto;
+import com.trekker.global.exception.enums.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인가 예외 핸들러
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper mapper;
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        log.warn("Authentication Failed: URI = {}, Method = {}, Message = {}",
+                request.getRequestURI(),
+                request.getMethod(),
+                authException.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResDto errorResponse = ErrorResDto.of(ErrorCode.ACCESS_AUTH_ENTRY_EXCEPTION);
+
+        response.getWriter().write(mapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
@@ -26,7 +26,6 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     private final RedisRepository redisRepository;
     private final OAuth2AuthorizedClientService authorizedClientService;
     private static final String TEMP_TOKEN_NAME = "tempToken";
-    private static final String GUEST = "isGuest";
     private static final String USER_ACCOUNT = "account";
     private static final String SUCCESS_URL = "http://localhost:3000/success-page";
 

--- a/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
@@ -1,0 +1,88 @@
+package com.trekker.global.config.security.handler;
+
+import com.trekker.global.auth.custom.CustomUserDetails;
+import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.config.security.TokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+    private final RedisRepository redisRepository;
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private static final String TEMP_TOKEN_NAME = "tempToken";
+    private static final String GUEST = "isGuest";
+    private static final String USER_ACCOUNT = "account";
+    private static final String SUCCESS_URL = "http://localhost:3000/success-page";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication) throws IOException {
+        CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
+        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+
+        // 최종 액세스 및 리프레시 토큰 생성
+        AuthResDto authResponse = tokenProvider.createAuthResponse(authentication);
+
+        // Redis에 authResponse 저장 및 임시 토큰 발급
+        String tempToken = redisRepository.storeAuthResponseWithTempToken(authResponse);
+        String account = oAuth2User.getEmail();
+
+        // 제공자가 google일 경우, 추후 회원 탈퇴를 위한 리프래시 토큰 저장
+        handleGoogleRefreshToken(authToken, account);
+
+        // 성공 URL에 쿼리 파라미터로 임시 토큰과 isGuest 정보를 전달
+        String redirectUrl = UriComponentsBuilder.fromUriString(SUCCESS_URL)
+                .queryParam(TEMP_TOKEN_NAME, tempToken)
+                .queryParam(USER_ACCOUNT, account)
+                .build().toUriString();
+
+        response.sendRedirect(redirectUrl); // 프론트엔드로 리다이렉트
+    }
+
+    /**
+     * Google 소셜 Refresh Token 저장 처리
+     */
+    private void handleGoogleRefreshToken(OAuth2AuthenticationToken authToken, String account) {
+        if (authToken.getAuthorizedClientRegistrationId().equals("google")) {
+            String socialRefreshToken = fetchGoogleRefreshToken(authToken);
+            if (socialRefreshToken != null) {
+                redisRepository.storeSocialRefreshTokenWithExtendedTTL(account, socialRefreshToken);
+                log.info("Google Refresh Token 저장 완료: {}", socialRefreshToken);
+            } else {
+                log.warn("Google Refresh Token을 가져오지 못했습니다. account={}", account);
+            }
+        }
+    }
+
+    /**
+     * Google Refresh Token을 가져오는 메서드
+     */
+    private String fetchGoogleRefreshToken(OAuth2AuthenticationToken authToken) {
+        // Spring Security에서 OAuth2AuthorizedClient 가져오기
+        OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+                authToken.getAuthorizedClientRegistrationId(),
+                authToken.getName());
+
+        if (client != null && client.getRefreshToken() != null) {
+            return client.getRefreshToken().getTokenValue();
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
@@ -27,7 +28,10 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     private final OAuth2AuthorizedClientService authorizedClientService;
     private static final String TEMP_TOKEN_NAME = "tempToken";
     private static final String USER_ACCOUNT = "account";
-    private static final String SUCCESS_URL = "http://localhost:3000/success-page";
+
+    @Value("${login.success-url}")
+    private String SUCCESS_URL;
+
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/trekker/global/config/web/WebMvcConfig.java
+++ b/src/main/java/com/trekker/global/config/web/WebMvcConfig.java
@@ -1,0 +1,15 @@
+package com.trekker.global.config.web;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/trekker/global/entity/AuditBaseEntity.java
+++ b/src/main/java/com/trekker/global/entity/AuditBaseEntity.java
@@ -1,4 +1,4 @@
-package com.trekker.global.config.entity;
+package com.trekker.global.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/trekker/global/entity/BaseEntity.java
+++ b/src/main/java/com/trekker/global/entity/BaseEntity.java
@@ -12,4 +12,9 @@ import lombok.NoArgsConstructor;
 public abstract class BaseEntity extends AuditBaseEntity {
 
     private boolean isDelete;
+
+    // 삭제 상태 변경 메서드
+    public void markAsDeleted() {
+        this.isDelete = true;
+    }
 }

--- a/src/main/java/com/trekker/global/entity/BaseEntity.java
+++ b/src/main/java/com/trekker/global/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.trekker.global.config.entity;
+package com.trekker.global.entity;
 
 import static lombok.AccessLevel.PROTECTED;
 

--- a/src/main/java/com/trekker/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/trekker/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,8 @@
-package com.trekker.global.config.exception;
+package com.trekker.global.exception;
 
-import com.trekker.global.config.exception.custom.BusinessException;
-import com.trekker.global.config.exception.dto.ErrorResDto;
-import com.trekker.global.config.exception.enums.ErrorCode;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.dto.ErrorResDto;
+import com.trekker.global.exception.enums.ErrorCode;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/trekker/global/exception/custom/BusinessException.java
+++ b/src/main/java/com/trekker/global/exception/custom/BusinessException.java
@@ -1,6 +1,6 @@
-package com.trekker.global.config.exception.custom;
+package com.trekker.global.exception.custom;
 
-import com.trekker.global.config.exception.enums.ErrorCode;
+import com.trekker.global.exception.enums.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/trekker/global/exception/dto/ErrorResDto.java
+++ b/src/main/java/com/trekker/global/exception/dto/ErrorResDto.java
@@ -1,6 +1,6 @@
-package com.trekker.global.config.exception.dto;
+package com.trekker.global.exception.dto;
 
-import com.trekker.global.config.exception.enums.ErrorCode;
+import com.trekker.global.exception.enums.ErrorCode;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.trekker.global.config.exception.enums;
+package com.trekker.global.exception.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
@@ -9,8 +9,16 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     //GLOBAL
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류")
-    ;
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류"),
+
+    //Security
+    ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "필요한 접근 권한이 없습니다."),
+    ACCESS_AUTH_ENTRY_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효한 자격이 없습니다."),
+
+    //JWT
+    INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 리프레시 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.");
 
     //오류 상태코드
     private final HttpStatus httpStatus;

--- a/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
@@ -18,7 +18,14 @@ public enum ErrorCode {
     //JWT
     INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 리프레시 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.");
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+
+    //Social
+    SOCIAL_UNLINK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 연결 해제에 실패했습니다."),
+    UNSUPPORTED_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 제공자입니다."),
+
+    //Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다.");
 
     //오류 상태코드
     private final HttpStatus httpStatus;

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,39 @@
+jwt:
+  secret: ${JWT_SECRET}
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            client-name: kakao
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope:
+              - profile
+              - email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth?prompt=consent&access_type=offline
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://openidconnect.googleapis.com/v1/userinfo
+
+kakao:
+  admin-key: ${KAKAO_ADMIN_KEY}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,5 +1,7 @@
 jwt:
   secret: ${JWT_SECRET}
+login:
+  success-url: http://localhost:3000/success-page
 
 spring:
   security:
@@ -36,4 +38,8 @@ spring:
             user-info-uri: https://openidconnect.googleapis.com/v1/userinfo
 
 kakao:
+  unlink-url: https://kapi.kakao.com/v1/user/unlink
   admin-key: ${KAKAO_ADMIN_KEY}
+
+google:
+  unlink-url: https://oauth2.googleapis.com/revoke

--- a/src/test/java/com/trekker/global/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/trekker/global/auth/application/AuthServiceTest.java
@@ -1,0 +1,145 @@
+package com.trekker.global.auth.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+import com.trekker.domain.member.dao.MemberRepository;
+import com.trekker.domain.member.entity.Member;
+import com.trekker.domain.member.entity.SocialProvider;
+import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.config.redis.dao.RedisRepository;
+import com.trekker.global.config.security.TokenProvider;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.enums.ErrorCode;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+    @InjectMocks
+    private AuthService authService;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private RedisRepository redisRepository;
+
+    @Mock
+    private UnlinkService unlinkService;
+
+    @Test
+    void logout() {
+        // given
+        String jwtToken = "validJwtToken";
+        String userId = "12345";
+        long expiration = 3600000L;
+
+        when(tokenProvider.getExpiration(jwtToken)).thenReturn(expiration);
+        when(tokenProvider.getUserIdFromToken(jwtToken)).thenReturn(userId);
+
+        // when
+        authService.logout(jwtToken);
+
+        // then
+        verify(redisRepository, times(1)).logoutTokens(jwtToken, expiration, userId);
+    }
+    @DisplayName("Refresh 토큰을 이용하여 새로운 Access 토큰을 발급한다.")
+    @Test
+    void refreshAccessToken() {
+        // given
+        String refreshToken = "validJwtToken";
+        String newToken = "newValidJwtToken";
+        AuthResDto authResDto = new AuthResDto(newToken, newToken);
+
+        when(tokenProvider.refreshAccessToken(refreshToken)).thenReturn(authResDto);
+
+        // when
+        AuthResDto authResdto = authService.refreshAccessToken(refreshToken);
+
+        // then
+        assertThat(authResdto.accessToken()).isEqualTo("newValidJwtToken");
+        verify(tokenProvider, times(1)).refreshAccessToken(refreshToken);
+    }
+
+    @DisplayName("유효하지 않은 Refresh 토큰으로 Access 토큰 발급 요청 시 예외가 발생한다.")
+    @Test
+    void failToRefreshAccessTokenWhenRefreshTokenIsInvalid() {
+        // given
+        String invalidRefreshToken = "invalidRefreshToken";
+
+        when(tokenProvider.refreshAccessToken(invalidRefreshToken))
+                .thenThrow(new BusinessException(invalidRefreshToken, "refreshToken", ErrorCode.INVALID_REFRESH_TOKEN));
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshAccessToken(invalidRefreshToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_REFRESH_TOKEN.getMessage());
+        verify(tokenProvider, times(1)).refreshAccessToken(invalidRefreshToken);
+    }
+    @DisplayName("임시 토큰으로 Redis에 저장되어 있는 토큰을 조회한다.")
+    @Test
+    void retrieveAuthResponse() {
+        // given
+        String tempToken = "tempToken";
+        String validToken = "validJwtToken";
+        AuthResDto authResDto = new AuthResDto(validToken, validToken);
+
+        when(redisRepository.retrieveAuthResponse(tempToken)).thenReturn(authResDto);
+
+        //when
+        AuthResDto resultDto = authService.retrieveAuthResponse(tempToken);
+
+        //then
+        assertThat(authResDto).isEqualTo(resultDto);
+    }
+
+    @DisplayName("회원 삭제 시 소셜 계정 연결이 끊기고 회원 상태가 삭제 처리된다.")
+    @Test
+    void deleteAccount() {
+        // given
+        String email = "test@example.com";
+        Member member = Member.builder()
+                .email(email)
+                .socialProvider(mock(SocialProvider.class))
+                .build();
+
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+
+        // when
+        authService.deleteAccount(email);
+
+        // then
+        verify(unlinkService, times(1)).unlink(member);
+        verify(memberRepository, times(1)).findByEmail(email);
+        assertThat(member.isDelete()).isTrue();
+    }
+
+    @DisplayName("존재하지 않는 회원 삭제 시 예외가 발생한다.")
+    @Test
+    void failToDeleteAccountWhenMemberNotFound() {
+        // given
+        String nonExistentEmail = "notexist@example.com";
+
+        when(memberRepository.findByEmail(nonExistentEmail)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.deleteAccount(nonExistentEmail))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+        verify(memberRepository, times(1)).findByEmail(nonExistentEmail);
+        verify(unlinkService, never()).unlink(any(Member.class));
+    }
+}

--- a/src/test/java/com/trekker/global/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/trekker/global/auth/application/AuthServiceTest.java
@@ -2,7 +2,6 @@ package com.trekker.global.auth.application;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 
@@ -15,13 +14,11 @@ import com.trekker.global.config.security.TokenProvider;
 import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
 import java.util.Optional;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -62,7 +59,7 @@ class AuthServiceTest {
         // given
         String refreshToken = "validJwtToken";
         String newToken = "newValidJwtToken";
-        AuthResDto authResDto = new AuthResDto(newToken, newToken);
+        AuthResDto authResDto = new AuthResDto(newToken, newToken, false);
 
         when(tokenProvider.refreshAccessToken(refreshToken)).thenReturn(authResDto);
 
@@ -95,7 +92,7 @@ class AuthServiceTest {
         // given
         String tempToken = "tempToken";
         String validToken = "validJwtToken";
-        AuthResDto authResDto = new AuthResDto(validToken, validToken);
+        AuthResDto authResDto = new AuthResDto(validToken, validToken, false);
 
         when(redisRepository.retrieveAuthResponse(tempToken)).thenReturn(authResDto);
 


### PR DESCRIPTION
## 🔥 Related Issue
close: #7 

## 📝 Description
소셜 로그인 인증 후 서비스 자체 JWT 토큰을 통해 인증/인가를 진행했습니다.
소셜 로그인 완료 시 임시 토큰이 발급되며, 임시 토큰으로 JWT 토큰 재 요청 시 Redis에서 조회하여 반환하는 방식으로 구현했습니다.
Refresh 토큰은 Redis 에서 관리하도록 구현했습니다.

`LoginMember`로 로그인 된 사용자의 email을 반환하는 커스텀 어노테이션도 구현하였습니다.

## ⭐️ Review
소셜로그인을 사용하기 위한 설정정보가 있는 yml 파일을 새로 만들었는데 기존 yml파일과 통합해야 될지 고민됩니다.
또 로그인 수행 시 별도의 로그아웃 요청이 없으면 계속 유지하는 구현 요구사항이 있었는데, 토큰 재발급 시 Access 토큰과 함께 Refresh 토큰도 계속 재발급 시키는 방식으로 구현하면 될지 고민입니다.