### PR TITLE
Chanbyoung/feature/#12 회고 crud 구현

### DIFF
--- a/src/main/java/com/trekker/domain/project/api/ProjectController.java
+++ b/src/main/java/com/trekker/domain/project/api/ProjectController.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import com.trekker.domain.project.application.ProjectService;
 import com.trekker.domain.project.dto.req.ProjectReqDto;
 import com.trekker.domain.project.dto.res.ProjectWithMemberInfoResDto;
+import com.trekker.domain.retrospective.dto.res.ProjectSkillSummaryResDto;
 import com.trekker.global.config.security.annotation.LoginMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -62,10 +63,19 @@ public class ProjectController {
     public ResponseEntity<Void> deleteProject(
             @LoginMember Long memberId,
             @PathVariable(name = "projectId") Long projectId
-            ) {
+    ) {
         projectService.deleteProject(memberId, projectId);
 
         return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @GetMapping("/{projectId}/skill-summary")
+    public ResponseEntity<ProjectSkillSummaryResDto> getProjectSkillSummary(
+            @LoginMember Long memberId,
+            @PathVariable Long projectId) {
+        ProjectSkillSummaryResDto summary = projectService.getProjectSkillSummary(memberId,
+                projectId);
+        return ResponseEntity.ok(summary);
     }
 }
 

--- a/src/main/java/com/trekker/domain/project/api/ProjectController.java
+++ b/src/main/java/com/trekker/domain/project/api/ProjectController.java
@@ -4,7 +4,9 @@ import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import com.trekker.domain.project.application.ProjectService;
+import com.trekker.domain.project.dto.req.ProjectExtendReqDto;
 import com.trekker.domain.project.dto.req.ProjectReqDto;
+import com.trekker.domain.project.dto.req.ProjectRetrospectiveReqDto;
 import com.trekker.domain.project.dto.res.ProjectWithMemberInfoResDto;
 import com.trekker.domain.retrospective.dto.res.ProjectSkillSummaryResDto;
 import com.trekker.global.config.security.annotation.LoginMember;
@@ -13,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -37,6 +40,7 @@ public class ProjectController {
 
         return ResponseEntity.status(CREATED).body(projectId);
     }
+
     @GetMapping
     public ResponseEntity<ProjectWithMemberInfoResDto> getProjectList(
             @LoginMember Long memberId,
@@ -72,10 +76,29 @@ public class ProjectController {
     @GetMapping("/{projectId}/skill-summary")
     public ResponseEntity<ProjectSkillSummaryResDto> getProjectSkillSummary(
             @LoginMember Long memberId,
-            @PathVariable Long projectId) {
+            @PathVariable(name = "projectId") Long projectId) {
         ProjectSkillSummaryResDto summary = projectService.getProjectSkillSummary(memberId,
                 projectId);
         return ResponseEntity.ok(summary);
+    }
+
+    @PostMapping("/{projectId}/close")
+    public ResponseEntity<Void> closeProject(
+            @LoginMember Long memberId,
+            @PathVariable(name = "projectId") Long projectId,
+            @Valid @RequestBody ProjectRetrospectiveReqDto reqDto) {
+        projectService.closeProject(memberId, projectId, reqDto);
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @PatchMapping("/{projectId}/extend")
+    public ResponseEntity<Void> extendProject(
+            @LoginMember Long memberId,
+            @PathVariable(name = "projectId") Long projectId,
+            @Valid @RequestBody ProjectExtendReqDto reqDto
+    ) {
+        projectService.extendProject(memberId, projectId, reqDto);
+        return ResponseEntity.status(NO_CONTENT).build();
     }
 }
 

--- a/src/main/java/com/trekker/domain/project/application/ProjectService.java
+++ b/src/main/java/com/trekker/domain/project/application/ProjectService.java
@@ -106,14 +106,17 @@ public class ProjectService {
         // 프로젝트 삭제
         projectRepository.delete(project);
     }
+
     public ProjectSkillSummaryResDto getProjectSkillSummary(Long memberId, Long projectId) {
         // 회원 및 프로젝트 조회 및 검증
         Project project = findProjectByIdWithMember(projectId);
         project.validateOwner(memberId);
 
+        // 상위 3개의 소프트 스킬 반환
         List<SkillCountDto> topSoftSkills = retrospectiveSkillRepository.findTopSkillsByType(
                 projectId, "소프트", PageRequest.of(0, 3));
 
+        // 상위 3개의 하드 스킬 반환
         List<SkillCountDto> topHardSkills = retrospectiveSkillRepository.findTopSkillsByType(
                 projectId, "하드", PageRequest.of(0, 3));
 

--- a/src/main/java/com/trekker/domain/project/application/ProjectService.java
+++ b/src/main/java/com/trekker/domain/project/application/ProjectService.java
@@ -8,12 +8,16 @@ import com.trekker.domain.project.dto.res.ProjectResDto;
 import com.trekker.domain.project.dto.res.ProjectWithMemberInfoResDto;
 import com.trekker.domain.project.entity.Project;
 import com.trekker.domain.project.util.ProjectProgressCalculator;
+import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
+import com.trekker.domain.retrospective.dto.res.ProjectSkillSummaryResDto;
+import com.trekker.domain.task.dto.SkillCountDto;
 import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +28,7 @@ public class ProjectService {
 
     private final ProjectRepository projectRepository;
     private final MemberRepository memberRepository;
+    private final RetrospectiveSkillRepository retrospectiveSkillRepository;
 
     @Transactional
     public Long addProject(Long memberId, ProjectReqDto projectReqDto) {
@@ -100,6 +105,19 @@ public class ProjectService {
 
         // 프로젝트 삭제
         projectRepository.delete(project);
+    }
+    public ProjectSkillSummaryResDto getProjectSkillSummary(Long memberId, Long projectId) {
+        // 회원 및 프로젝트 조회 및 검증
+        Project project = findProjectByIdWithMember(projectId);
+        project.validateOwner(memberId);
+
+        List<SkillCountDto> topSoftSkills = retrospectiveSkillRepository.findTopSkillsByType(
+                projectId, "소프트", PageRequest.of(0, 3));
+
+        List<SkillCountDto> topHardSkills = retrospectiveSkillRepository.findTopSkillsByType(
+                projectId, "하드", PageRequest.of(0, 3));
+
+        return ProjectSkillSummaryResDto.toDto(project, topSoftSkills, topHardSkills);
     }
 
     /**

--- a/src/main/java/com/trekker/domain/project/dao/ProjectRetrospectiveRepository.java
+++ b/src/main/java/com/trekker/domain/project/dao/ProjectRetrospectiveRepository.java
@@ -1,0 +1,8 @@
+package com.trekker.domain.project.dao;
+
+import com.trekker.domain.project.entity.ProjectRetrospective;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRetrospectiveRepository extends JpaRepository<ProjectRetrospective ,Long> {
+
+}

--- a/src/main/java/com/trekker/domain/project/dto/req/ProjectExtendReqDto.java
+++ b/src/main/java/com/trekker/domain/project/dto/req/ProjectExtendReqDto.java
@@ -1,0 +1,10 @@
+package com.trekker.domain.project.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record ProjectExtendReqDto (
+        @NotNull LocalDate endDate
+        ) {
+
+}

--- a/src/main/java/com/trekker/domain/project/dto/req/ProjectRetrospectiveReqDto.java
+++ b/src/main/java/com/trekker/domain/project/dto/req/ProjectRetrospectiveReqDto.java
@@ -1,0 +1,18 @@
+package com.trekker.domain.project.dto.req;
+
+import com.trekker.domain.project.entity.Project;
+import com.trekker.domain.project.entity.ProjectRetrospective;
+import jakarta.validation.constraints.Size;
+
+public record ProjectRetrospectiveReqDto(
+        @Size(max = 300, message = "제목은 최대 20 자까지 입력 가능합니다.")
+        String content
+) {
+    public ProjectRetrospective toEntity(Project project) {
+        return ProjectRetrospective.builder()
+                .project(project)
+                .content(this.content)
+                .build();
+    }
+
+}

--- a/src/main/java/com/trekker/domain/project/entity/Project.java
+++ b/src/main/java/com/trekker/domain/project/entity/Project.java
@@ -4,18 +4,25 @@ import static jakarta.persistence.FetchType.LAZY;
 
 import com.trekker.domain.member.entity.Member;
 import com.trekker.domain.project.dto.req.ProjectReqDto;
+import com.trekker.domain.task.entity.Task;
 import com.trekker.global.entity.BaseEntity;
 import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,9 +61,13 @@ public class Project extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<Task> taskList = new ArrayList<>();
+
     @Builder
     public Project(Long id, String type, String title, String description, LocalDate startDate,
-            LocalDate endDate, Boolean isCompleted, Member member) {
+            LocalDate endDate, Boolean isCompleted, Member member, List<Task> taskList) {
         this.id = id;
         this.type = type;
         this.title = title;
@@ -65,6 +76,7 @@ public class Project extends BaseEntity {
         this.endDate = endDate;
         this.isCompleted = isCompleted;
         this.member = member;
+        this.taskList = taskList;
     }
     public void validateOwner(Long memberId) {
         if (!this.member.getId().equals(memberId)) {

--- a/src/main/java/com/trekker/domain/project/entity/Project.java
+++ b/src/main/java/com/trekker/domain/project/entity/Project.java
@@ -18,7 +18,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -90,5 +89,16 @@ public class Project extends BaseEntity {
         this.description = projectReqDto.description();
         this.startDate = projectReqDto.startDate();
         this.endDate = projectReqDto.endDate();
+    }
+
+    public void updateCompleted() {
+        this.isCompleted = true;
+    }
+
+    public void updateEndDate(LocalDate endDate) {
+        if (this.isCompleted) {
+            throw new BusinessException(isCompleted, "isCompleted", ErrorCode.PROJECT_BAD_REQUEST);
+        }
+        this.endDate = endDate;
     }
 }

--- a/src/main/java/com/trekker/domain/project/entity/ProjectRetrospective.java
+++ b/src/main/java/com/trekker/domain/project/entity/ProjectRetrospective.java
@@ -1,0 +1,43 @@
+package com.trekker.domain.project.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.trekker.domain.task.entity.Task;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "project_retrospectives")
+public class ProjectRetrospective {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "project_id", nullable = false)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Builder
+    public ProjectRetrospective(Long id, Project project, String content) {
+        this.id = id;
+        this.project = project;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/trekker/domain/retrospective/api/RetrospectiveController.java
+++ b/src/main/java/com/trekker/domain/retrospective/api/RetrospectiveController.java
@@ -1,0 +1,76 @@
+package com.trekker.domain.retrospective.api;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import com.trekker.domain.retrospective.application.RetrospectiveService;
+import com.trekker.domain.retrospective.dto.req.RetrospectiveReqDto;
+import com.trekker.domain.retrospective.dto.res.RetrospectiveResDto;
+import com.trekker.global.config.security.annotation.LoginMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/tasks/{taskId}/retrospectives")
+public class RetrospectiveController {
+
+    private final RetrospectiveService retrospectiveService;
+
+    @PostMapping
+    public ResponseEntity<Long> addRetrospective(
+            @LoginMember Long memberId,
+            @PathVariable(name = "taskId") Long taskId,
+            @Valid @RequestBody RetrospectiveReqDto reqDto
+    ) {
+        Long retrospectiveId = retrospectiveService.addRetrospective(memberId, taskId, reqDto);
+        return ResponseEntity.status(CREATED).body(retrospectiveId);
+    }
+
+    @GetMapping("/{retrospectiveId}")
+    public ResponseEntity<RetrospectiveResDto> getRetrospective(
+            @LoginMember Long memberId,
+            @PathVariable(name = "taskId") Long taskId,
+            @PathVariable(name = "retrospectiveId") Long retrospectiveId) {
+        RetrospectiveResDto retrospective = retrospectiveService.getRetrospective(memberId, taskId,
+                retrospectiveId);
+
+        return ResponseEntity.ok(retrospective);
+    }
+
+    @PutMapping("/{retrospectiveId}")
+    public ResponseEntity<Void> updateRetrospective(
+            @LoginMember Long memberId,
+            @PathVariable(name = "taskId") Long taskId,
+            @PathVariable(name = "retrospectiveId") Long retrospectiveId,
+            @Valid @RequestBody RetrospectiveReqDto reqDto
+    ) {
+        retrospectiveService.updateRetrospective(memberId, taskId, retrospectiveId, reqDto);
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{retrospectiveId}")
+    public ResponseEntity<Void> deleteRetrospective(
+            @LoginMember Long memberId,
+            @PathVariable(name = "taskId") Long taskId,
+            @PathVariable(name = "retrospectiveId") Long retrospectiveId) {
+
+        retrospectiveService.deleteRetrospective(memberId, taskId,
+                retrospectiveId);
+
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/api/RetrospectiveController.java
+++ b/src/main/java/com/trekker/domain/retrospective/api/RetrospectiveController.java
@@ -37,37 +37,33 @@ public class RetrospectiveController {
         return ResponseEntity.status(CREATED).body(retrospectiveId);
     }
 
-    @GetMapping("/{retrospectiveId}")
+    @GetMapping
     public ResponseEntity<RetrospectiveResDto> getRetrospective(
             @LoginMember Long memberId,
-            @PathVariable(name = "taskId") Long taskId,
-            @PathVariable(name = "retrospectiveId") Long retrospectiveId) {
-        RetrospectiveResDto retrospective = retrospectiveService.getRetrospective(memberId, taskId,
-                retrospectiveId);
+            @PathVariable(name = "taskId") Long taskId
+    ) {
+        RetrospectiveResDto retrospective = retrospectiveService.getRetrospective(memberId, taskId);
 
         return ResponseEntity.ok(retrospective);
     }
 
-    @PutMapping("/{retrospectiveId}")
+    @PutMapping
     public ResponseEntity<Void> updateRetrospective(
             @LoginMember Long memberId,
             @PathVariable(name = "taskId") Long taskId,
-            @PathVariable(name = "retrospectiveId") Long retrospectiveId,
             @Valid @RequestBody RetrospectiveReqDto reqDto
     ) {
-        retrospectiveService.updateRetrospective(memberId, taskId, retrospectiveId, reqDto);
+        retrospectiveService.updateRetrospective(memberId, taskId, reqDto);
 
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    @DeleteMapping("/{retrospectiveId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteRetrospective(
             @LoginMember Long memberId,
-            @PathVariable(name = "taskId") Long taskId,
-            @PathVariable(name = "retrospectiveId") Long retrospectiveId) {
+            @PathVariable(name = "taskId") Long taskId) {
 
-        retrospectiveService.deleteRetrospective(memberId, taskId,
-                retrospectiveId);
+        retrospectiveService.deleteRetrospective(memberId, taskId);
 
         return ResponseEntity.status(NO_CONTENT).build();
     }

--- a/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
+++ b/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
@@ -35,6 +35,7 @@ public class RetrospectiveService {
 
     /**
      * 새로운 회고를 추가
+     * 회고에 연관된 소프트 및 하드 스킬을 RetrospectiveSkill 엔티티로 변환하여 일괄 저장합니다.
      */
     @Transactional
     public Long addRetrospective(Long memberId, Long taskId, RetrospectiveReqDto reqDto) {
@@ -57,6 +58,15 @@ public class RetrospectiveService {
         return retrospective.getId();
     }
 
+    /**
+     * 기존 회고를 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param taskId 할 일 ID
+     * @param retrospectiveId 회고 ID
+     * @return 할일 이름, 회고 내용과 소프트/하드 스킬이 포함된 DTO
+     */
+
     public RetrospectiveResDto getRetrospective(Long memberId, Long taskId, Long retrospectiveId) {
         // 1. 할 일 작성자 확인
         Task task = validateTaskOwnership(memberId, taskId);
@@ -69,7 +79,8 @@ public class RetrospectiveService {
     }
 
     /**
-     * 기존 회고를 업데이트
+     * 기존 회고를 업데이트합니다.
+     * 회고 내용과 관련 스킬을 갱신합니다.
      */
     @Transactional
     public void updateRetrospective(Long memberId, Long taskId, Long retrospectiveId,
@@ -87,6 +98,10 @@ public class RetrospectiveService {
         updateRetrospectiveSkills(retrospective, reqDto);
     }
 
+    /**
+     * 기존 회고를 삭제합니다.
+     * 회고 삭제시 RetrospectiveSkill 도 함께 삭제됩니다.
+     */
     @Transactional
     public void deleteRetrospective(Long memberId, Long taskId, Long retrospectiveId) {
         // 1. 할 일 작성자 확인
@@ -104,7 +119,7 @@ public class RetrospectiveService {
     /**
      * 회고와 연결된 스킬 데이터를 저장
      *
-     * 요청된 소프트 및 하드 스킬 데이터를 회고 엔티티와 연결하여 RetrospectiveSkill 엔티티로 변환하고, 이를 데이터베이스에 Batch 방식으로 저장합니다.
+     * 요청된 소프트 및 하드 스킬 데이터를 회고 엔티티와 연결하여 RetrospectiveSkill 엔티티로 변환하고,
      * 이를 데이터베이스에 Batch 방식으로 저장합니다.
      *
      * @param retrospective 회고 엔티티
@@ -129,10 +144,8 @@ public class RetrospectiveService {
         retrospectiveSkills.addAll(softSkills);
         retrospectiveSkills.addAll(hardSkills);
 
-        // 변환된 RetrospectiveSkill 리스트가 비어있지 않으면 배치로 저장
-        if (!retrospectiveSkills.isEmpty()) {
-            retrospectiveSkillRepository.saveAll(retrospectiveSkills);
-        }
+        // 변환된 RetrospectiveSkill 리스트 배치로 저장
+        retrospectiveSkillRepository.saveAll(retrospectiveSkills);
     }
 
     /**

--- a/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
+++ b/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
@@ -12,7 +12,6 @@ import com.trekker.domain.task.dao.TaskRepository;
 import com.trekker.domain.task.entity.Task;
 import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
+++ b/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
@@ -1,0 +1,225 @@
+package com.trekker.domain.retrospective.application;
+
+import com.trekker.domain.retrospective.dao.RetrospectiveRepository;
+import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
+import com.trekker.domain.retrospective.dao.SkillRepository;
+import com.trekker.domain.retrospective.dto.req.RetrospectiveReqDto;
+import com.trekker.domain.retrospective.entity.Retrospective;
+import com.trekker.domain.retrospective.entity.RetrospectiveSkill;
+import com.trekker.domain.retrospective.entity.Skill;
+import com.trekker.domain.task.dao.TaskRepository;
+import com.trekker.domain.task.entity.Task;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.enums.ErrorCode;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RetrospectiveService {
+
+    private final RetrospectiveRepository retrospectiveRepository;
+    private final RetrospectiveSkillRepository retrospectiveSkillRepository;
+    private final SkillRepository skillRepository;
+    private final TaskRepository taskRepository;
+
+    /**
+     * 새로운 회고를 추가하는 메서드
+     */
+    @Transactional
+    public Long addRetrospective(Long memberId, Long taskId, RetrospectiveReqDto reqDto) {
+        // 1. 태스크 소유권 검증 및 완료 여부 확인
+        Task task = validateTaskOwnership(memberId, taskId);
+        validateTaskCompletion(task);
+
+        // 2. 새로운 회고 엔티티 생성 및 저장
+        Retrospective retrospective = retrospectiveRepository.save(reqDto.toEntity(task));
+
+        // 3. 스킬 데이터 조회 또는 생성
+        Map<String, Skill> skillMap = findOrCreateSkills(reqDto);
+
+        // 4. 회고와 연결된 스킬 저장
+        saveRetrospectiveSkills(retrospective, reqDto, skillMap);
+
+        // 5. 태스크 완료 상태 업데이트
+        task.updateCompleted(true);
+
+        return retrospective.getId();
+    }
+
+    /**
+     * 기존 회고를 업데이트하는 메서드
+     */
+    @Transactional
+    public void updateRetrospective(Long memberId, Long taskId, Long retrospectiveId,
+            RetrospectiveReqDto reqDto) {
+        // 1. 태스크 소유권 검증
+        validateTaskOwnership(memberId, taskId);
+
+        // 2. 회고 엔티티 및 관련 데이터 조회
+        Retrospective retrospective = findByIdWithSkillListAndSkill(retrospectiveId);
+
+        // 3. 회고 내용 업데이트
+        retrospective.updateContent(reqDto.content());
+
+        // 4. 기존 스킬과 새로운 스킬 비교 및 갱신
+        updateRetrospectiveSkills(retrospective, reqDto);
+    }
+
+    /**
+     * 회고와 연결된 스킬 데이터를 저장
+     * <p>
+     * 요청된 소프트 및 하드 스킬 데이터를 회고 엔티티와 연결하여 RetrospectiveSkill 엔티티로 변환하고, 이를 데이터베이스에 Batch 방식으로 저장합니다.
+     * 스킬 이름을 기준으로 Skill 객체를 매핑하여 처리합니다.
+     *
+     * @param retrospective 회고 엔티티
+     * @param reqDto        요청 DTO
+     * @param skillMap      스킬 이름과 객체 매핑
+     */
+    private void saveRetrospectiveSkills(Retrospective retrospective, RetrospectiveReqDto reqDto,
+            Map<String, Skill> skillMap) {
+        // 1. 요청된 스킬 데이터를 소프트/하드로 구분하여 처리
+        List<RetrospectiveSkill> retrospectiveSkills = Stream.concat(
+                reqDto.softSkillList().stream()
+                        .map(name -> RetrospectiveSkill.toEntity("소프트", retrospective,
+                                skillMap.get(name))),
+                reqDto.hardSkillList().stream()
+                        .map(name -> RetrospectiveSkill.toEntity("하드", retrospective,
+                                skillMap.get(name)))
+        ).toList();
+
+        // 2. Batch 저장 처리
+        retrospectiveSkillRepository.saveAll(retrospectiveSkills);
+    }
+
+    /**
+     * 기존 회고의 스킬 데이터를 업데이트
+     *
+     * @param retrospective 회고 엔티티
+     * @param reqDto        요청 DTO
+     */
+    private void updateRetrospectiveSkills(Retrospective retrospective,
+            RetrospectiveReqDto reqDto) {
+        // 1. 요청된 스킬에 대한 Skill 엔티티를 가져옴
+        Map<String, Skill> skillMap = findOrCreateSkills(reqDto);
+
+        // 2. 기존 및 요청된 스킬 데이터를 Map으로 변환
+        // 기존 RetrospectiveSkill 데이터를 Map 형태로 변환
+        Map<String, RetrospectiveSkill> existingSkills = retrospective.getRetrospectiveSkillList()
+                .stream()
+                .collect(Collectors.toMap(
+                        retrospectiveSkill -> retrospectiveSkill.getSkill().getName(), // 스킬 이름
+                        retrospectiveSkill -> retrospectiveSkill // RetrospectiveSkill 객체
+                ));
+        Map<String, String> requestedSkillMap = createRequestedSkillMap(reqDto);
+
+        // 3. 삭제 작업: 요청에 없는 기존 스킬 삭제
+        retrospectiveSkillRepository.deleteAll(
+                existingSkills.values().stream()
+                        .filter(skill -> !requestedSkillMap.containsKey(skill.getSkill().getName()))
+                        .toList()
+        );
+
+        // 4. 추가 작업: 요청된 스킬 중 기존에 없는 스킬 추가
+        retrospectiveSkillRepository.saveAll(
+                requestedSkillMap.entrySet().stream()
+                        .filter(entry -> !existingSkills.containsKey(entry.getKey()))
+                        .map(entry -> RetrospectiveSkill.toEntity(entry.getValue(), retrospective,
+                                skillMap.get(entry.getKey())))
+                        .toList()
+        );
+    }
+
+    private Map<String, String> createRequestedSkillMap(RetrospectiveReqDto reqDto) {
+        return Stream.concat(
+                reqDto.softSkillList().stream().map(skillName -> Map.entry(skillName, "소프트")),
+                reqDto.hardSkillList().stream().map(skillName -> Map.entry(skillName, "하드"))
+        ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+
+    /**
+     * 요청된 스킬 데이터를 조회하거나 새로 생성하여 반환
+     *
+     * @param reqDto 요청 DTO
+     * @return 스킬 이름과 스킬 객체 매핑
+     */
+    private Map<String, Skill> findOrCreateSkills(RetrospectiveReqDto reqDto) {
+        // 1. 요청된 소프트 스킬과 하드 스킬 이름을 합침
+        Set<String> skillNames = new HashSet<>();
+        skillNames.addAll(reqDto.softSkillList());
+        skillNames.addAll(reqDto.hardSkillList());
+
+        // 2. 기존 스킬 조회
+        Map<String, Skill> skillMap = skillRepository.findByNameIn(skillNames).stream()
+                .collect(Collectors.toMap(Skill::getName, skill -> skill));
+
+        // 3. 새로운 스킬을 개별적으로 생성
+        for (String name : skillNames) {
+            if (!skillMap.containsKey(name)) {
+                Skill newSkill = Skill.toEntity(name);
+                skillRepository.save(newSkill);
+                skillMap.put(name, newSkill);   // 맵에 추가
+            }
+        }
+
+        return skillMap;
+    }
+
+    /**
+     * 태스크의 소유권을 검증하는 메서드
+     *
+     * @param memberId 사용자 ID
+     * @param taskId   태스크 ID
+     * @return 검증된 Task 엔티티
+     */
+    private Task validateTaskOwnership(Long memberId, Long taskId) {
+        Task task = findTaskById(taskId);
+        task.getProject().validateOwner(memberId);
+        return task;
+    }
+
+    /**
+     * 특정 ID의 태스크를 조회하는 메서드
+     *
+     * @param taskId 태스크 ID
+     * @return 조회된 Task 엔티티
+     */
+    private Task findTaskById(Long taskId) {
+        return taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(taskId)
+                .orElseThrow(
+                        () -> new BusinessException(taskId, "taskId", ErrorCode.TASK_NOT_FOUND));
+    }
+
+    /**
+     * 태스크가 이미 완료 상태인지 확인하는 메서드
+     *
+     * @param task 확인할 태스크
+     */
+    private void validateTaskCompletion(Task task) {
+        if (task.getIsCompleted()) {
+            throw new BusinessException(task.getId(), "taskId",
+                    ErrorCode.RETROSPECTIVE_BAD_REQUEST);
+        }
+    }
+
+    /**
+     * 특정 태스크에 연결된 회고를 조회하는 메서드
+     *
+     * @param retrospectiveId 회고 ID
+     * @return 조회된 Retrospective 엔티티
+     */
+    private Retrospective findByIdWithSkillListAndSkill(Long retrospectiveId) {
+        return retrospectiveRepository.findByIdWithSkillListAndSkill(retrospectiveId)
+                .orElseThrow(() -> new BusinessException(retrospectiveId, "retrospectiveId",
+                        ErrorCode.RETROSPECTIVE_NOT_FOUND));
+    }
+
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveRepository.java
@@ -15,5 +15,5 @@ public interface RetrospectiveRepository extends JpaRepository<Retrospective, Lo
           JOIN FETCH sl.skill
           WHERE r.id =:retrospectiveId
           """)
-   Optional<Retrospective> findByIdWithSkillListAndSkill(@Param("retrospectiveId") Long retrospectiveId);
+   Optional<Retrospective> findByIdWithSkillList(@Param("retrospectiveId") Long retrospectiveId);
 }

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveRepository.java
@@ -1,0 +1,8 @@
+package com.trekker.domain.retrospective.dao;
+
+import com.trekker.domain.retrospective.entity.Retrospective;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RetrospectiveRepository extends JpaRepository<Retrospective, Long> {
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveRepository.java
@@ -1,8 +1,19 @@
 package com.trekker.domain.retrospective.dao;
 
 import com.trekker.domain.retrospective.entity.Retrospective;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RetrospectiveRepository extends JpaRepository<Retrospective, Long> {
 
+   @Query("""
+          SELECT r
+          FROM Retrospective r
+          JOIN FETCH r.retrospectiveSkillList sl
+          JOIN FETCH sl.skill
+          WHERE r.id =:retrospectiveId
+          """)
+   Optional<Retrospective> findByIdWithSkillListAndSkill(@Param("retrospectiveId") Long retrospectiveId);
 }

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
@@ -1,0 +1,9 @@
+package com.trekker.domain.retrospective.dao;
+
+import com.trekker.domain.retrospective.entity.RetrospectiveSkill;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RetrospectiveSkillRepository extends JpaRepository<RetrospectiveSkill, Long> {
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
@@ -1,9 +1,28 @@
 package com.trekker.domain.retrospective.dao;
 
 import com.trekker.domain.retrospective.entity.RetrospectiveSkill;
+import com.trekker.domain.task.dto.SkillCountDto;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RetrospectiveSkillRepository extends JpaRepository<RetrospectiveSkill, Long> {
+
+    @Query("""
+           SELECT new com.trekker.domain.task.dto.SkillCountDto(rs.skill.name, COUNT(rs.skill.name))
+           FROM RetrospectiveSkill rs
+           JOIN rs.retrospective r
+           JOIN r.task t
+           JOIN t.project p
+           WHERE p.id = :projectId AND rs.type = :type
+           GROUP BY rs.skill.name
+           ORDER BY COUNT(rs.skill.name) DESC
+           """)
+    List<SkillCountDto> findTopSkillsByType(@Param("projectId") Long projectId,
+            @Param("type") String type,
+            Pageable pageable);
+
 
 }

--- a/src/main/java/com/trekker/domain/retrospective/dao/SkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/SkillRepository.java
@@ -10,13 +10,13 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SkillRepository extends JpaRepository<Skill, Long> {
+
     // 이름 목록에 해당하는 Skill을 연관 데이터를 패치 조인으로 조회
     @Query("""
-           SELECT s 
-           FROM Skill s 
-           LEFT JOIN FETCH s.retrospectiveSkillList 
+           SELECT s
+           FROM Skill s
            WHERE s.name IN :names
            """)
-    List<Skill> findByNameInWithRestrospectiveSkillList(@Param("names") Collection<String> names);
+    List<Skill> findByNameIn(@Param("names") Collection<String> names);
 
 }

--- a/src/main/java/com/trekker/domain/retrospective/dao/SkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/SkillRepository.java
@@ -1,0 +1,22 @@
+package com.trekker.domain.retrospective.dao;
+
+import com.trekker.domain.retrospective.entity.Skill;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SkillRepository extends JpaRepository<Skill, Long> {
+    // 이름 목록에 해당하는 Skill을 연관 데이터를 패치 조인으로 조회
+    @Query("""
+           SELECT s 
+           FROM Skill s 
+           LEFT JOIN FETCH s.retrospectiveSkillList 
+           WHERE s.name IN :names
+           """)
+    List<Skill> findByNameInWithRestrospectiveSkillList(@Param("names") Collection<String> names);
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
+++ b/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
@@ -25,7 +25,7 @@ public record RetrospectiveReqDto(
         return Retrospective.builder()
                 .task(task)
                 .content(content)
-                .skillList(new ArrayList<>()) // 초기 빈 리스트
+                .retrospectiveSkillList(new ArrayList<>()) // 초기 빈 리스트
                 .build();
     }
 

--- a/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
+++ b/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
@@ -2,18 +2,23 @@ package com.trekker.domain.retrospective.dto.req;
 
 import com.trekker.domain.retrospective.entity.Retrospective;
 import com.trekker.domain.task.entity.Task;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 
 public record RetrospectiveReqDto(
 
         // 소프트 스틸 목록
+        @NotNull(message = "소프트 스킬 목록은 필수입니다.")
         List<String> softSkillList,
 
         // 하드 스킬 목록
+        @NotNull(message = "하드 스킬 목록은 필수입니다.")
         List<String> hardSkillList,
 
         // 회고  내용
+        @Size(max = 300, message = "내용은 최대 300 자까지 입력 가능합니다.")
         String content
 ) {
 

--- a/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
+++ b/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
@@ -6,7 +6,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record RetrospectiveReqDto(
 
         // 소프트 스틸 목록

--- a/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
+++ b/src/main/java/com/trekker/domain/retrospective/dto/req/RetrospectiveReqDto.java
@@ -1,0 +1,32 @@
+package com.trekker.domain.retrospective.dto.req;
+
+import com.trekker.domain.retrospective.entity.Retrospective;
+import com.trekker.domain.task.entity.Task;
+import java.util.ArrayList;
+import java.util.List;
+
+public record RetrospectiveReqDto(
+
+        // 소프트 스틸 목록
+        List<String> softSkillList,
+
+        // 하드 스킬 목록
+        List<String> hardSkillList,
+
+        // 회고  내용
+        String content
+) {
+
+    /**
+     * Retrospective 엔티티로 변환
+     */
+    public Retrospective toEntity(Task task) {
+
+        return Retrospective.builder()
+                .task(task)
+                .content(content)
+                .skillList(new ArrayList<>()) // 초기 빈 리스트
+                .build();
+    }
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/dto/res/ProjectSkillSummaryResDto.java
+++ b/src/main/java/com/trekker/domain/retrospective/dto/res/ProjectSkillSummaryResDto.java
@@ -1,0 +1,36 @@
+package com.trekker.domain.retrospective.dto.res;
+
+import com.trekker.domain.project.entity.Project;
+import com.trekker.domain.task.dto.SkillCountDto;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ProjectSkillSummaryResDto(
+        Long projectId,
+        String title,
+        LocalDate startDate,
+        LocalDate endDate,
+
+        //상위 3개 반환
+        List<SkillCountDto> topSoftSkillList,
+        List<SkillCountDto> topHardSkillList
+
+) {
+
+    public static ProjectSkillSummaryResDto toDto(Project project,
+            List<SkillCountDto> topSoftSkillList, List<SkillCountDto> topHardSkillList) {
+        return ProjectSkillSummaryResDto.builder()
+                .projectId(project.getId())
+                .title(project.getTitle())
+                .startDate(project.getStartDate())
+                .endDate(project.getEndDate())
+                .topSoftSkillList(topSoftSkillList)
+                .topHardSkillList(topHardSkillList)
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/trekker/domain/retrospective/dto/res/RetrospectiveResDto.java
+++ b/src/main/java/com/trekker/domain/retrospective/dto/res/RetrospectiveResDto.java
@@ -1,0 +1,42 @@
+package com.trekker.domain.retrospective.dto.res;
+
+import com.trekker.domain.retrospective.entity.Retrospective;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RetrospectiveResDto(
+
+        String taskName,
+
+        // 소프트 스틸 목록
+        List<String> softSkillList,
+
+        // 하드 스킬 목록
+        List<String> hardSkillList,
+
+        // 회고  내용
+        String content
+) {
+
+    public static RetrospectiveResDto toDto(String taskName, Retrospective retrospective) {
+        // 소프트 및 하드 스킬 목록 초기화
+        List<String> softSkillList = retrospective.getRetrospectiveSkillList().stream()
+                .filter(skill -> "소프트".equals(skill.getType()))
+                .map(skill -> skill.getSkill().getName())
+                .toList();
+
+        List<String> hardSkillList = retrospective.getRetrospectiveSkillList().stream()
+                .filter(skill -> "하드".equals(skill.getType()))
+                .map(skill -> skill.getSkill().getName())
+                .toList();
+
+        // DTO 빌더를 통해 반환
+        return RetrospectiveResDto.builder()
+                .taskName(taskName)
+                .softSkillList(softSkillList)
+                .hardSkillList(hardSkillList)
+                .content(retrospective.getContent()) // 회고 내용 가져오기
+                .build();
+    }
+}

--- a/src/main/java/com/trekker/domain/retrospective/entity/Retrospective.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/Retrospective.java
@@ -1,0 +1,57 @@
+package com.trekker.domain.retrospective.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.trekker.domain.task.entity.Task;
+import com.trekker.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "retrospectives")
+public class Retrospective extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "retrospective_id", nullable = false)
+    private Long id;
+
+    // 회고의 내용
+    @Column(name = "content")
+    private String content;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "task_id", nullable = false)
+    private Task task;
+
+    @OneToMany(mappedBy = "retrospective", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RetrospectiveSkill> skillList = new ArrayList<>();
+
+    @Builder
+    public Retrospective(Long id, String content, Task task, List<RetrospectiveSkill> skillList) {
+        this.id = id;
+        this.content = content;
+        this.task = task;
+        this.skillList = skillList;
+    }
+
+    public void updateSkillList(RetrospectiveSkill retrospectiveSkill) {
+        this.skillList.add((retrospectiveSkill));
+    }
+}

--- a/src/main/java/com/trekker/domain/retrospective/entity/Retrospective.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/Retrospective.java
@@ -37,7 +37,7 @@ public class Retrospective extends BaseEntity {
     private String content;
 
     @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "task_id", nullable = false)
+    @JoinColumn(name = "task_id")
     private Task task;
 
     @OneToMany(mappedBy = "retrospective", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/trekker/domain/retrospective/entity/Retrospective.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/Retrospective.java
@@ -41,17 +41,17 @@ public class Retrospective extends BaseEntity {
     private Task task;
 
     @OneToMany(mappedBy = "retrospective", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<RetrospectiveSkill> skillList = new ArrayList<>();
+    private List<RetrospectiveSkill> retrospectiveSkillList = new ArrayList<>();
 
     @Builder
-    public Retrospective(Long id, String content, Task task, List<RetrospectiveSkill> skillList) {
+    public Retrospective(Long id, String content, Task task, List<RetrospectiveSkill> retrospectiveSkillList) {
         this.id = id;
         this.content = content;
         this.task = task;
-        this.skillList = skillList;
+        this.retrospectiveSkillList = retrospectiveSkillList;
     }
 
-    public void updateSkillList(RetrospectiveSkill retrospectiveSkill) {
-        this.skillList.add((retrospectiveSkill));
+    public void updateContent(String content) {
+        this.content =content;
     }
 }

--- a/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
@@ -40,7 +40,7 @@ public class RetrospectiveSkill {
     @JoinColumn(name = "retrospective_id", nullable = false)
     private Retrospective retrospective;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "skill_id", nullable = false)
     private Skill skill;
 

--- a/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
@@ -22,7 +22,6 @@ import lombok.NoArgsConstructor;
 @Table(name = "retrospective_skills")
 public class RetrospectiveSkill {
 
-
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "retrospective_skill_seq")
     @SequenceGenerator(
@@ -36,11 +35,11 @@ public class RetrospectiveSkill {
     @Column(name = "type", nullable = false)
     private String type;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "retrospective_id", nullable = false)
     private Retrospective retrospective;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "skill_id", nullable = false)
     private Skill skill;
 

--- a/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
@@ -27,7 +27,7 @@ public class RetrospectiveSkill {
     @SequenceGenerator(
             name = "retrospective_skill_seq",
             sequenceName = "retrospective_skill_sequence",
-            allocationSize = 10
+            allocationSize = 30
     )
     private Long id;
 

--- a/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/RetrospectiveSkill.java
@@ -1,0 +1,63 @@
+package com.trekker.domain.retrospective.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "retrospective_skills")
+public class RetrospectiveSkill {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "retrospective_skill_seq")
+    @SequenceGenerator(
+            name = "retrospective_skill_seq",
+            sequenceName = "retrospective_skill_sequence",
+            allocationSize = 10
+    )
+    private Long id;
+
+    // 스킬의 유형 (소프트, 하드)
+    @Column(name = "type", nullable = false)
+    private String type;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "retrospective_id", nullable = false)
+    private Retrospective retrospective;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "skill_id", nullable = false)
+    private Skill skill;
+
+    @Builder
+    public RetrospectiveSkill(Long id, String type, Retrospective retrospective, Skill skill) {
+        this.id = id;
+        this.type = type;
+        this.retrospective = retrospective;
+        this.skill = skill;
+    }
+
+    public static RetrospectiveSkill toEntity(String type, Retrospective retrospective,
+            Skill skill) {
+        return RetrospectiveSkill.builder()
+                .type(type)
+                .retrospective(retrospective)
+                .skill(skill)
+                .build();
+    }
+}

--- a/src/main/java/com/trekker/domain/retrospective/entity/Skill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/Skill.java
@@ -1,0 +1,44 @@
+package com.trekker.domain.retrospective.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "skills")
+public class Skill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "skill_id", nullable = false)
+    private Long id;
+
+    // 스킬 이름
+    @Column(name = "name")
+    private String name;
+
+    @OneToMany(mappedBy = "skill", orphanRemoval = true)
+    private List<RetrospectiveSkill> retrospectiveSkillList = new ArrayList<>();
+
+    @Builder
+    public Skill(Long id, String name, List<RetrospectiveSkill> retrospectiveSkillList) {
+        this.id = id;
+        this.name = name;
+        this.retrospectiveSkillList = retrospectiveSkillList;
+    }
+}

--- a/src/main/java/com/trekker/domain/retrospective/entity/Skill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/Skill.java
@@ -1,14 +1,11 @@
 package com.trekker.domain.retrospective.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,5 +37,11 @@ public class Skill {
         this.id = id;
         this.name = name;
         this.retrospectiveSkillList = retrospectiveSkillList;
+    }
+
+    public static Skill toEntity(String name) {
+        return Skill.builder()
+                .name(name)
+                .build();
     }
 }

--- a/src/main/java/com/trekker/domain/retrospective/entity/Skill.java
+++ b/src/main/java/com/trekker/domain/retrospective/entity/Skill.java
@@ -29,14 +29,10 @@ public class Skill {
     @Column(name = "name")
     private String name;
 
-    @OneToMany(mappedBy = "skill", orphanRemoval = true)
-    private List<RetrospectiveSkill> retrospectiveSkillList = new ArrayList<>();
-
     @Builder
-    public Skill(Long id, String name, List<RetrospectiveSkill> retrospectiveSkillList) {
+    public Skill(Long id, String name) {
         this.id = id;
         this.name = name;
-        this.retrospectiveSkillList = retrospectiveSkillList;
     }
 
     public static Skill toEntity(String name) {

--- a/src/main/java/com/trekker/domain/task/dao/TaskRepository.java
+++ b/src/main/java/com/trekker/domain/task/dao/TaskRepository.java
@@ -23,6 +23,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
            SELECT t
            FROM Task t
            JOIN FETCH t.project
+           LEFT JOIN FETCH t.retrospective
            WHERE t.project.id = :projectId
            AND (
                (t.endDate IS NULL AND t.startDate BETWEEN :startDate AND :endDate) OR
@@ -32,4 +33,14 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     List<Task> findTasksWithinDateRange(@Param("projectId") Long projectId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    @Query("""
+           SELECT t
+           FROM Task t
+           JOIN FETCH t.project p
+           LEFT JOIN fetch t.retrospective r
+           JOIN FETCH p.member m
+           WHERE t.id =:taskId
+           """)
+    Optional<Task> findTaskByIdWithProjectAndMemberWithRetrospective(@Param("taskId") Long taskId);
 }

--- a/src/main/java/com/trekker/domain/task/dto/SkillCountDto.java
+++ b/src/main/java/com/trekker/domain/task/dto/SkillCountDto.java
@@ -1,0 +1,8 @@
+package com.trekker.domain.task.dto;
+
+public record SkillCountDto(
+        String skillName,
+        Long count
+) {
+
+}

--- a/src/main/java/com/trekker/domain/task/entity/Task.java
+++ b/src/main/java/com/trekker/domain/task/entity/Task.java
@@ -1,8 +1,10 @@
 package com.trekker.domain.task.entity;
 
 import com.trekker.domain.project.entity.Project;
+import com.trekker.domain.retrospective.entity.Retrospective;
 import com.trekker.domain.task.dto.req.TaskReqDto;
 import com.trekker.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
@@ -45,19 +48,27 @@ public class Task extends BaseEntity {
     @JoinColumn(name = "project_id")
     private Project project;
 
+    @OneToOne(mappedBy = "task", fetch = FetchType.LAZY,  cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Retrospective retrospective;
+
     @Builder
     public Task(Long id, String name, LocalDate start_date, LocalDate end_date, Boolean isCompleted,
-            Project project) {
+            Project project, Retrospective retrospective) {
         this.id = id;
         this.name = name;
         this.startDate = start_date;
         this.endDate = end_date;
         this.isCompleted = isCompleted;
         this.project = project;
+        this.retrospective = retrospective;
     }
 
     public void updateTask(TaskReqDto taskReqDto) {
         this.name = taskReqDto.name();
         this.endDate = taskReqDto.endDate();
+    }
+
+    public void updateCompleted(boolean isCompleted) {
+        this.isCompleted = isCompleted;
     }
 }

--- a/src/main/java/com/trekker/domain/task/entity/Task.java
+++ b/src/main/java/com/trekker/domain/task/entity/Task.java
@@ -71,4 +71,9 @@ public class Task extends BaseEntity {
     public void updateCompleted(Boolean isCompleted) {
         this.isCompleted = isCompleted;
     }
+
+    public void unlinkRetrospectiveAndUpdateCompleted(){
+        this.isCompleted = false;
+        this.retrospective = null;
+    }
 }

--- a/src/main/java/com/trekker/domain/task/entity/Task.java
+++ b/src/main/java/com/trekker/domain/task/entity/Task.java
@@ -48,7 +48,7 @@ public class Task extends BaseEntity {
     @JoinColumn(name = "project_id")
     private Project project;
 
-    @OneToOne(mappedBy = "task", fetch = FetchType.LAZY,  cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToOne(mappedBy = "task", fetch = FetchType.LAZY,cascade = CascadeType.PERSIST, orphanRemoval = true)
     private Retrospective retrospective;
 
     @Builder
@@ -68,7 +68,7 @@ public class Task extends BaseEntity {
         this.endDate = taskReqDto.endDate();
     }
 
-    public void updateCompleted(boolean isCompleted) {
+    public void updateCompleted(Boolean isCompleted) {
         this.isCompleted = isCompleted;
     }
 }

--- a/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
+++ b/src/main/java/com/trekker/global/exception/enums/ErrorCode.java
@@ -34,7 +34,11 @@ public enum ErrorCode {
 
     //Task
     TASK_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "할 일 정보를 찾을 수 없습니다.");
+    TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "할 일 정보를 찾을 수 없습니다."),
+
+    //Retrospective
+    RETROSPECTIVE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    RETROSPECTIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "회고를 찾을 수 없습니다.");
 
     //오류 상태코드
     private final HttpStatus httpStatus;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,7 +20,7 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        jdbc.batch_size: 10
+        jdbc.batch_size: 30
         order_inserts: true
         order_updates: true
         jdbc:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,13 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        jdbc.batch_size: 10
+        order_inserts: true
+        order_updates: true
+        jdbc:
+          batch_versioned_data: true
 
 #p6spy
 decorator:

--- a/src/test/java/com/trekker/domain/retrospective/application/RetrospectiveServiceTest.java
+++ b/src/test/java/com/trekker/domain/retrospective/application/RetrospectiveServiceTest.java
@@ -1,7 +1,6 @@
 package com.trekker.domain.retrospective.application;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.trekker.domain.member.entity.Member;

--- a/src/test/java/com/trekker/domain/retrospective/application/RetrospectiveServiceTest.java
+++ b/src/test/java/com/trekker/domain/retrospective/application/RetrospectiveServiceTest.java
@@ -55,12 +55,6 @@ class RetrospectiveServiceTest {
 
     @BeforeEach
     void setUp() {
-        task = Task.builder()
-                .id(1L)
-                .isCompleted(false)
-                .project(Project.builder().id(1L).member(Member.builder().id(1L).build()).build())
-                .build();
-
         softSkill = Skill.builder()
                 .id(1L)
                 .name("커뮤니케이션")
@@ -82,6 +76,13 @@ class RetrospectiveServiceTest {
                 .content("Initial Retrospective")
                 .task(task)
                 .retrospectiveSkillList(new ArrayList<>())
+                .build();
+
+        task = Task.builder()
+                .id(1L)
+                .isCompleted(false)
+                .retrospective(retrospective)
+                .project(Project.builder().id(1L).member(Member.builder().id(1L).build()).build())
                 .build();
 
         memberId = 1L;
@@ -158,8 +159,7 @@ class RetrospectiveServiceTest {
                 .thenReturn(Optional.of(retrospective));
 
         // when
-        RetrospectiveResDto resDto = retrospectiveService.getRetrospective(memberId, task.getId(),
-                retrospective.getId());
+        RetrospectiveResDto resDto = retrospectiveService.getRetrospective(memberId, task.getId());
 
         // then
         assertThat(resDto.softSkillList().size()).isEqualTo(1);
@@ -193,8 +193,7 @@ class RetrospectiveServiceTest {
                 .thenReturn(Arrays.asList(softSkill, hardSkill));
 
         // when
-        retrospectiveService.updateRetrospective(memberId, task.getId(), retrospective.getId(),
-                updateDto);
+        retrospectiveService.updateRetrospective(memberId, task.getId(), updateDto);
 
         // then
         assertThat(retrospective.getContent()).isEqualTo(updateDto.content());
@@ -210,19 +209,17 @@ class RetrospectiveServiceTest {
         Task completedTask = Task.builder()
                 .id(1L)
                 .project(Project.builder().id(1L).member(Member.builder().id(memberId).build()).build())
+                .retrospective(retrospective)
                 .isCompleted(true)
                 .build();
 
         when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
                 .thenReturn(Optional.of(completedTask));
-        when(retrospectiveRepository.findByIdWithSkillList(retrospective.getId()))
-                .thenReturn(Optional.of(retrospective));
 
         // when
-        retrospectiveService.deleteRetrospective(memberId, task.getId(), retrospective.getId());
+        retrospectiveService.deleteRetrospective(memberId, task.getId());
 
         // then
         assertThat(task.getIsCompleted()).isEqualTo(false);
-        verify(retrospectiveRepository, times(1)).delete(retrospective);
     }
 }

--- a/src/test/java/com/trekker/domain/retrospective/application/RetrospectiveServiceTest.java
+++ b/src/test/java/com/trekker/domain/retrospective/application/RetrospectiveServiceTest.java
@@ -1,0 +1,229 @@
+package com.trekker.domain.retrospective.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.trekker.domain.member.entity.Member;
+import com.trekker.domain.project.entity.Project;
+import com.trekker.domain.retrospective.dao.RetrospectiveRepository;
+import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
+import com.trekker.domain.retrospective.dao.SkillRepository;
+import com.trekker.domain.retrospective.dto.req.RetrospectiveReqDto;
+import com.trekker.domain.retrospective.dto.res.RetrospectiveResDto;
+import com.trekker.domain.retrospective.entity.Retrospective;
+import com.trekker.domain.retrospective.entity.RetrospectiveSkill;
+import com.trekker.domain.retrospective.entity.Skill;
+import com.trekker.domain.task.dao.TaskRepository;
+import com.trekker.domain.task.entity.Task;
+import com.trekker.global.exception.custom.BusinessException;
+import com.trekker.global.exception.enums.ErrorCode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RetrospectiveServiceTest {
+
+    @InjectMocks
+    private RetrospectiveService retrospectiveService;
+    @Mock
+    private RetrospectiveRepository retrospectiveRepository;
+    @Mock
+    private RetrospectiveSkillRepository retrospectiveSkillRepository;
+    @Mock
+    private SkillRepository skillRepository;
+    @Mock
+    private TaskRepository taskRepository;
+
+    private Task task;
+    private Skill softSkill;
+    private Skill hardSkill;
+    private RetrospectiveReqDto reqDto;
+    private Retrospective retrospective;
+
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        task = Task.builder()
+                .id(1L)
+                .isCompleted(false)
+                .project(Project.builder().id(1L).member(Member.builder().id(1L).build()).build())
+                .build();
+
+        softSkill = Skill.builder()
+                .id(1L)
+                .name("커뮤니케이션")
+                .build();
+
+        hardSkill = Skill.builder()
+                .id(2L)
+                .name("Spring")
+                .build();
+
+        reqDto = RetrospectiveReqDto.builder()
+                .content("Updated Retrospective")
+                .softSkillList(List.of("Java"))
+                .hardSkillList(List.of("Spring"))
+                .build();
+
+        retrospective = Retrospective.builder()
+                .id(1L)
+                .content("Initial Retrospective")
+                .task(task)
+                .retrospectiveSkillList(new ArrayList<>())
+                .build();
+
+        memberId = 1L;
+    }
+
+    @DisplayName("새로운 회고를 추가합니다.")
+    @Test
+    void addRetrospective() {
+        // given
+        when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
+                .thenReturn(Optional.of(task));
+        when(retrospectiveRepository.save(any(Retrospective.class))).thenReturn(retrospective);
+        when(skillRepository.findByNameIn(anySet()))
+                .thenReturn(Arrays.asList(softSkill, hardSkill));
+
+        // when
+        Long retrospectiveId = retrospectiveService.addRetrospective(memberId, task.getId(), reqDto);
+
+        // then
+        assertThat(retrospectiveId).isEqualTo(retrospective.getId());
+        assertThat(task.getIsCompleted()).isEqualTo(true);
+        verify(retrospectiveRepository, times(1)).save(any(Retrospective.class));
+    }
+
+    @DisplayName("존재하지 않는 태스크로 회고를 추가하려 하면 예외가 발생한다.")
+    @Test
+    void addRetrospectiveFailTaskNotFound() {
+        // given
+        when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> retrospectiveService.addRetrospective(memberId, task.getId(), reqDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.TASK_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("이미 완료된 테스크에 회고를 추가하려 하면 예외가 발생한다.")
+    @Test
+    void addRetrospectiveFailTaskAlreadyCompleted() {
+        // given
+        Task completedTask = Task.builder()
+                .id(1L)
+                .project(Project.builder().id(1L).member(Member.builder().id(memberId).build()).build())
+                .isCompleted(true)
+                .build();
+
+        when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
+                .thenReturn(Optional.of(completedTask));
+
+        // when
+        assertThatThrownBy(() -> retrospectiveService.addRetrospective(memberId, task.getId(), reqDto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.TASK_BAD_REQUEST.getMessage());
+
+    }
+
+    @DisplayName("기존 회고를 조회한다.")
+    @Test
+    void getRetrospective() {
+        // given
+        retrospective.getRetrospectiveSkillList().add(
+                RetrospectiveSkill.builder()
+                        .id(1L)
+                        .skill(softSkill)
+                        .type("소프트")
+                        .retrospective(retrospective)
+                        .build()
+        );
+
+        when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
+                .thenReturn(Optional.of(task));
+        when(retrospectiveRepository.findByIdWithSkillList(retrospective.getId()))
+                .thenReturn(Optional.of(retrospective));
+
+        // when
+        RetrospectiveResDto resDto = retrospectiveService.getRetrospective(memberId, task.getId(),
+                retrospective.getId());
+
+        // then
+        assertThat(resDto.softSkillList().size()).isEqualTo(1);
+        assertThat(resDto.content()).isEqualTo(retrospective.getContent());
+    }
+
+    @DisplayName("기존 회고를 업데이트 한다.")
+    @Test
+    void updateRetrospective() {
+        // given
+        RetrospectiveReqDto updateDto = RetrospectiveReqDto.builder()
+                .content("Updated Content")
+                .softSkillList(List.of("Java"))
+                .hardSkillList(List.of("Spring"))
+                .build();
+
+        retrospective.getRetrospectiveSkillList().add(
+                RetrospectiveSkill.builder()
+                        .id(1L)
+                        .skill(softSkill)
+                        .type("소프트")
+                        .retrospective(retrospective)
+                        .build()
+        );
+
+        when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
+                .thenReturn(Optional.of(task));
+        when(retrospectiveRepository.findByIdWithSkillList(retrospective.getId()))
+                .thenReturn(Optional.of(retrospective));
+        when(skillRepository.findByNameIn(anySet()))
+                .thenReturn(Arrays.asList(softSkill, hardSkill));
+
+        // when
+        retrospectiveService.updateRetrospective(memberId, task.getId(), retrospective.getId(),
+                updateDto);
+
+        // then
+        assertThat(retrospective.getContent()).isEqualTo(updateDto.content());
+        verify(retrospectiveSkillRepository, times(1)).deleteAll(anyList());
+        verify(retrospectiveSkillRepository, times(1)).saveAll(anyList());
+    }
+
+
+    @DisplayName("기존 회고를 삭제한다.")
+    @Test
+    void deleteRetrospective() {
+        // given
+        Task completedTask = Task.builder()
+                .id(1L)
+                .project(Project.builder().id(1L).member(Member.builder().id(memberId).build()).build())
+                .isCompleted(true)
+                .build();
+
+        when(taskRepository.findTaskByIdWithProjectAndMemberWithRetrospective(task.getId()))
+                .thenReturn(Optional.of(completedTask));
+        when(retrospectiveRepository.findByIdWithSkillList(retrospective.getId()))
+                .thenReturn(Optional.of(retrospective));
+
+        // when
+        retrospectiveService.deleteRetrospective(memberId, task.getId(), retrospective.getId());
+
+        // then
+        assertThat(task.getIsCompleted()).isEqualTo(false);
+        verify(retrospectiveRepository, times(1)).delete(retrospective);
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
close: #12 

## 📝 Description
회고 CRUD를 구현했습니다.
회고 생성, 수정, 삭제시 연관된 스킬들도 같이 업데이트 됩니다.

추가적으로 프로젝트 종료 및 연장처리 기능도 구현했습니다.
- 프로젝트 종료 요청 시 프로젝트의 사용 스킬 목록을 필터링하여 반환하고, 종료 요청 후에는 프로젝트의 완료 여부와 프로젝트 전체 회고를 업데이트 합니다.
- 프로젝트 연장 시 프로젝트 종료 일자만 업데이트 합니다.

## ⭐️ Review
