### PR TITLE
Chanbyoung/feature/#17 회원 리포트 구현

### DIFF
--- a/src/main/java/com/trekker/domain/report/api/ReportController.java
+++ b/src/main/java/com/trekker/domain/report/api/ReportController.java
@@ -1,0 +1,28 @@
+package com.trekker.domain.report.api;
+
+import com.trekker.domain.report.dto.ReportResDto;
+import com.trekker.domain.report.service.ReportService;
+import com.trekker.global.config.security.annotation.LoginMember;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping
+    public ResponseEntity<ReportResDto> getMemberReport(
+            @LoginMember Long memberId
+    ) {
+        ReportResDto memberReport = reportService.getMemberReport(memberId);
+
+        return ResponseEntity.ok(memberReport);
+    }
+
+}

--- a/src/main/java/com/trekker/domain/report/api/ReportController.java
+++ b/src/main/java/com/trekker/domain/report/api/ReportController.java
@@ -2,11 +2,14 @@ package com.trekker.domain.report.api;
 
 import com.trekker.domain.report.dto.ReportResDto;
 import com.trekker.domain.report.service.ReportService;
+import com.trekker.domain.task.dto.SkillCountDto;
 import com.trekker.global.config.security.annotation.LoginMember;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,6 +26,16 @@ public class ReportController {
         ReportResDto memberReport = reportService.getMemberReport(memberId);
 
         return ResponseEntity.ok(memberReport);
+    }
+
+    @GetMapping("/skill")
+    public ResponseEntity<List<SkillCountDto>> getMemberSkill(
+            @LoginMember Long memberId,
+            @RequestParam String type
+    ) {
+        List<SkillCountDto> memberSkillList = reportService.getMemberSkillList(memberId, type);
+
+        return ResponseEntity.ok(memberSkillList);
     }
 
 }

--- a/src/main/java/com/trekker/domain/report/dto/ReportResDto.java
+++ b/src/main/java/com/trekker/domain/report/dto/ReportResDto.java
@@ -11,7 +11,7 @@ public record ReportResDto(
         List<SkillCountDto> hardSkillList,
 
         //월 별 진행률
-        Map<LocalDate, Integer> monthlyTaskRate,
+        Map<LocalDate, Integer> dailyProgressRatesInMonth,
         // 주간 작업 완료 횟수
         Map<LocalDate, Integer> weeklyCompletedTasks
 ) {

--- a/src/main/java/com/trekker/domain/report/dto/ReportResDto.java
+++ b/src/main/java/com/trekker/domain/report/dto/ReportResDto.java
@@ -1,11 +1,19 @@
 package com.trekker.domain.report.dto;
 
 import com.trekker.domain.task.dto.SkillCountDto;
+import jakarta.persistence.criteria.CriteriaBuilder.In;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 public record ReportResDto(
         List<SkillCountDto> softSkillList,
-        List<SkillCountDto> hardSkillList
+        List<SkillCountDto> hardSkillList,
+
+        //월 별 진행률
+        Map<LocalDate, Integer> monthlyTaskRate,
+        // 주간 작업 완료 횟수
+        Map<LocalDate, Integer> weeklyCompletedTasks
 ) {
 
 }

--- a/src/main/java/com/trekker/domain/report/dto/ReportResDto.java
+++ b/src/main/java/com/trekker/domain/report/dto/ReportResDto.java
@@ -1,0 +1,11 @@
+package com.trekker.domain.report.dto;
+
+import com.trekker.domain.task.dto.SkillCountDto;
+import java.util.List;
+
+public record ReportResDto(
+        List<SkillCountDto> softSkillList,
+        List<SkillCountDto> hardSkillList
+) {
+
+}

--- a/src/main/java/com/trekker/domain/report/service/ReportService.java
+++ b/src/main/java/com/trekker/domain/report/service/ReportService.java
@@ -1,0 +1,36 @@
+package com.trekker.domain.report.service;
+
+import com.trekker.domain.report.dto.ReportResDto;
+import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
+import com.trekker.domain.task.dto.SkillCountDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private static final String SOFT_SKILL = "소프트";
+    private static final String HARD_SKILL = "소프트";
+
+
+
+    private final RetrospectiveSkillRepository retrospectiveSkillRepository;
+
+
+    public ReportResDto getMemberReport(Long memberId) {
+
+        // 상위 3개의 소프트 스킬 반환
+        List<SkillCountDto> topSoftSkills = retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(
+                memberId, SOFT_SKILL, PageRequest.of(0, 3));
+
+        // 상위 3개의 하드 스킬 반환
+        List<SkillCountDto> topHardSkills = retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(
+                memberId, HARD_SKILL, PageRequest.of(0, 3));
+
+        return new ReportResDto(topSoftSkills, topHardSkills);
+    }
+
+}

--- a/src/main/java/com/trekker/domain/report/service/ReportService.java
+++ b/src/main/java/com/trekker/domain/report/service/ReportService.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -69,7 +70,8 @@ public class ReportService {
      * @return 조회한 스킬 리스트
      */
     public List<SkillCountDto> getMemberSkillList(Long memberId, String type) {
-        return retrospectiveSkillRepository.findSkillsByMemberIdAndType(memberId, type);
+        return retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, type,
+                Pageable.unpaged());
     }
 
     /**

--- a/src/main/java/com/trekker/domain/report/service/ReportService.java
+++ b/src/main/java/com/trekker/domain/report/service/ReportService.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -55,6 +56,10 @@ public class ReportService {
                 dailyTaskStatsInMonth);
 
         return new ReportResDto(topSoftSkills, topHardSkills, monthlyTaskRate, weeklyTaskCounts);
+    }
+
+    public List<SkillCountDto> getMemberSkillList(Long memberId, String type) {
+        return retrospectiveSkillRepository.findSkillsByMemberIdAndType(memberId, type);
     }
 
     /**

--- a/src/main/java/com/trekker/domain/report/service/ReportService.java
+++ b/src/main/java/com/trekker/domain/report/service/ReportService.java
@@ -1,9 +1,17 @@
 package com.trekker.domain.report.service;
 
 import com.trekker.domain.report.dto.ReportResDto;
+import com.trekker.domain.report.util.ProgressRateUtil;
 import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
+import com.trekker.domain.task.dao.TaskRepository;
 import com.trekker.domain.task.dto.SkillCountDto;
+import com.trekker.domain.task.entity.Task;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -13,13 +21,17 @@ import org.springframework.stereotype.Service;
 public class ReportService {
 
     private static final String SOFT_SKILL = "소프트";
-    private static final String HARD_SKILL = "소프트";
-
-
+    private static final String HARD_SKILL = "하드";
 
     private final RetrospectiveSkillRepository retrospectiveSkillRepository;
+    private final TaskRepository taskRepository;
 
 
+    /**
+     * 회원의 보고서를 반환합니다
+     * @param memberId 회원의 ID
+     * @return 상위 소프트/하드 스킬, 이번 달의 날짜별 진행률, 주간 완료된 작업 수를 계산한 데이터를 담는 DTO
+     */
     public ReportResDto getMemberReport(Long memberId) {
 
         // 상위 3개의 소프트 스킬 반환
@@ -30,7 +42,96 @@ public class ReportService {
         List<SkillCountDto> topHardSkills = retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(
                 memberId, HARD_SKILL, PageRequest.of(0, 3));
 
-        return new ReportResDto(topSoftSkills, topHardSkills);
+        // 이번 달의 날짜별 작업 통계 계산
+        Map<LocalDate, Map<String, Integer>> dailyTaskStatsInMonth = getDailyTaskStatsInMonth(
+                memberId);
+
+        // 이번 달의 날짜별 작업 진행률 계산
+        Map<LocalDate, Integer> monthlyTaskRate = ProgressRateUtil.calculateProgressRate(
+                dailyTaskStatsInMonth);
+
+        // 이번 주의 일별 완료된 작업 수 계산
+        Map<LocalDate, Integer> weeklyTaskCounts = getLastWeekToThisSaturdayTasks(
+                dailyTaskStatsInMonth);
+
+        return new ReportResDto(topSoftSkills, topHardSkills, monthlyTaskRate, weeklyTaskCounts);
+    }
+
+    /**
+     * 이번 달의 날짜별 전체 작업 및 완료된 작업 통계를 가져옵니다.
+     *
+     * @param memberId 멤버 ID
+     * @return 날짜별 작업 통계 (전체 작업 수, 완료된 작업 수)
+     */
+    private Map<LocalDate, Map<String, Integer>> getDailyTaskStatsInMonth(Long memberId) {
+        Map<LocalDate, Map<String, Integer>> dailyStats = new HashMap<>();
+
+        // 현재 날짜를 기준으로 이번 달의 시작일과 종료일 계산
+        LocalDate now = LocalDate.now();
+        LocalDate startOfMonth = LocalDate.of(now.getYear(), now.getMonth(), 1);
+        LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+
+        // 멤버의 이번 달 작업 조회
+        List<Task> tasks = taskRepository.findTasksInMonth(memberId, startOfMonth, endOfMonth);
+
+        // 작업의 날짜별 전체 및 완료된 작업 수 계산
+        for (Task task : tasks) {
+            // 작업 기간 계산
+            LocalDate startDate = task.getStartDate();
+            LocalDate endDate = (task.getEndDate() != null) ? task.getEndDate() : startDate;
+
+            // 작업 기간을 이번 달 범위 내로 제한
+            LocalDate current = startDate.isBefore(startOfMonth) ? startOfMonth : startDate;
+            LocalDate end = endDate.isAfter(endOfMonth) ? endOfMonth : endDate;
+
+            // 작업 기간 동안 각 날짜별 작업 수 계산
+            while (!current.isAfter(end)) {
+                // 작업이 완료된 경우, 완료된 작업 수를 증가시킴
+                dailyStats.putIfAbsent(current, new HashMap<>());
+
+                Map<String, Integer> stats = dailyStats.get(current);
+
+                // 전체 작업 수를 증가시킴
+                stats.put("totalTasks", stats.getOrDefault("totalTasks", 0) + 1);
+
+                // 작업이 완료된 경우, 완료된 작업 수를 증가시킴
+                if (task.getIsCompleted()) {
+                    stats.put("completedTasks", stats.getOrDefault("completedTasks", 0) + 1);
+                }
+
+                // 다음 날짜로 이동
+                current = current.plusDays(1);
+            }
+        }
+
+        return dailyStats;
+    }
+
+    /**
+     * 주어진 일별 작업 통계에서 저번 주 일요일부터 이번 주 토요일까지의 작업 데이터를 필터링합니다.
+     *
+     * @param dailyTaskStats 날짜 별 작업 통계
+     * @return 저번 주 일요일부터 이번 주 토요일까지의 날짜별 완료된 작업 수 맵
+     */
+    private Map<LocalDate, Integer> getLastWeekToThisSaturdayTasks(
+            Map<LocalDate, Map<String, Integer>> dailyTaskStats) {
+        Map<LocalDate, Integer> weeklyCompletedTasks = new HashMap<>();
+
+        // 현재 날짜를 기준으로 저번 주 일요일과 이번 주 토요일 계산
+        LocalDate now = LocalDate.now();
+        LocalDate lastSunday = now.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
+        LocalDate thisSaturday = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+
+        // 주어진 작업 통계에서 해당 주 범위의 데이터를 필터링
+        for (Map.Entry<LocalDate, Map<String, Integer>> entry : dailyTaskStats.entrySet()) {
+            LocalDate date = entry.getKey();
+            if (!date.isBefore(lastSunday) && !date.isAfter(thisSaturday)) {
+                int completedTasks = entry.getValue().getOrDefault("completedTasks", 0);
+                weeklyCompletedTasks.put(date, completedTasks);
+            }
+        }
+
+        return weeklyCompletedTasks;
     }
 
 }

--- a/src/main/java/com/trekker/domain/report/util/ProgressRateCalculator.java
+++ b/src/main/java/com/trekker/domain/report/util/ProgressRateCalculator.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
  * 진행률은 완료된 작업 수를 기준으로 계산되며, 사전 정의된 구간 값으로 반환됩니다.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ProgressRateUtil {
+public class ProgressRateCalculator {
 
     private static final int PROGRESS_20 = 20;
     private static final int PROGRESS_40 = 40;

--- a/src/main/java/com/trekker/domain/report/util/ProgressRateCalculator.java
+++ b/src/main/java/com/trekker/domain/report/util/ProgressRateCalculator.java
@@ -3,6 +3,7 @@ package com.trekker.domain.report.util;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -28,39 +29,56 @@ public class ProgressRateCalculator {
     public static Map<LocalDate, Integer> calculateProgressRate(
             Map<LocalDate, Map<String, Integer>> monthlyTask) {
 
-        Map<LocalDate, Integer> monthlyTaskProgress = new HashMap<>();
+        // 월별 작업 통계를 스트림으로 처리하여 진행률 맵 생성
+        return monthlyTask.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, // 날짜를 키로 사용
+                        entry -> calculateMappedProgressRate(entry.getValue())
+                ));
+    }
 
-        for (Map.Entry<LocalDate, Map<String, Integer>> entry : monthlyTask.entrySet()) {
-            LocalDate date = entry.getKey();
-            Map<String, Integer> dailyStats = entry.getValue();
+    /**
+     * 일별 작업 통계를 기반으로 매핑된 진행률을 계산합니다.
+     *
+     * @param dailyStats 일별 작업 통계
+     * @return 매핑된 진행률
+     */
+    private static int calculateMappedProgressRate(Map<String, Integer> dailyStats) {
+        // 일별 작업 수 및 완료된 작업 수 가져오기
+        int completedTaskCount = dailyStats.getOrDefault("completedTasks", 0);
+        int totalTaskCount = dailyStats.getOrDefault("totalTasks", 0);
 
-            // 작업 개수 가져오기
-            Integer totalTaskCount = dailyStats.getOrDefault("totalTasks", 0);
-            Integer completedTaskCount = dailyStats.getOrDefault("completedTasks", 0);
-
-            // 완료한 작업 수가 0인 경우 진행률은 0으로 간주
-            if (completedTaskCount == 0) {
-                monthlyTaskProgress.put(date, 0);
-                continue;
-            }
-
-            // 진행률 계산
-            double progressRate = (completedTaskCount / (double) totalTaskCount) * 100;
-
-            // 조건에 따라 진행률 매핑
-            if (progressRate <= 30) {
-                monthlyTaskProgress.put(date, PROGRESS_20);
-            } else if (progressRate <= 50) {
-                monthlyTaskProgress.put(date, PROGRESS_40);
-            } else if (progressRate <= 70) {
-                monthlyTaskProgress.put(date, PROGRESS_60);
-            } else if (progressRate <= 99) {
-                monthlyTaskProgress.put(date, PROGRESS_80);
-            } else {
-                monthlyTaskProgress.put(date, PROGRESS_100);
-            }
+        // 완료한 작업 수가 0이거나 총 작업 수가 0인 경우 진행률은 0으로 설정
+        if (completedTaskCount == 0 || totalTaskCount == 0) {
+            return 0;
         }
 
-        return monthlyTaskProgress;
+        // 실제 진행률 계산
+        double progressRate = (completedTaskCount / (double) totalTaskCount) * 100;
+
+        // 실제 진행률을 사전 정의된 구간 값으로 매핑
+        return mapProgressRate(progressRate);
     }
+
+    /**
+     * 실제 진행률을 사전 정의된 구간 값으로 매핑합니다.
+     *
+     * @param progressRate 실제 계산된 진행률
+     * @return 매핑된 진행률
+     */
+    private static int mapProgressRate(double progressRate) {
+        if (progressRate <= 30) {
+            return PROGRESS_20;
+        } else if (progressRate <= 50) {
+            return PROGRESS_40;
+        } else if (progressRate <= 70) {
+            return PROGRESS_60;
+        } else if (progressRate <= 99) {
+            return PROGRESS_80;
+        } else {
+            return PROGRESS_100;
+        }
+    }
+
 }

--- a/src/main/java/com/trekker/domain/report/util/ProgressRateUtil.java
+++ b/src/main/java/com/trekker/domain/report/util/ProgressRateUtil.java
@@ -1,0 +1,66 @@
+package com.trekker.domain.report.util;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 날짜별 작업 통계를 기반으로 진행률을 계산하는 유틸리티 클래스입니다.
+ * 진행률은 완료된 작업 수를 기준으로 계산되며, 사전 정의된 구간 값으로 반환됩니다.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProgressRateUtil {
+
+    private static final int PROGRESS_20 = 20;
+    private static final int PROGRESS_40 = 40;
+    private static final int PROGRESS_60 = 60;
+    private static final int PROGRESS_80 = 80;
+    private static final int PROGRESS_100 = 100;
+
+    /**
+     * 월별 진행률을 계산합니다.
+     *
+     * @param monthlyTask 날짜별 작업 통계
+     * @return 날짜별 진행률
+     */
+    public static Map<LocalDate, Integer> calculateProgressRate(
+            Map<LocalDate, Map<String, Integer>> monthlyTask) {
+
+        Map<LocalDate, Integer> monthlyTaskProgress = new HashMap<>();
+
+        for (Map.Entry<LocalDate, Map<String, Integer>> entry : monthlyTask.entrySet()) {
+            LocalDate date = entry.getKey();
+            Map<String, Integer> dailyStats = entry.getValue();
+
+            // 작업 개수 가져오기
+            Integer totalTaskCount = dailyStats.getOrDefault("totalTasks", 0);
+            Integer completedTaskCount = dailyStats.getOrDefault("completedTasks", 0);
+
+            // 완료한 작업 수가 0인 경우 진행률은 0으로 간주
+            if (completedTaskCount == 0) {
+                monthlyTaskProgress.put(date, 0);
+                continue;
+            }
+
+            // 진행률 계산
+            double progressRate = (completedTaskCount / (double) totalTaskCount) * 100;
+
+            // 조건에 따라 진행률 매핑
+            if (progressRate <= 30) {
+                monthlyTaskProgress.put(date, PROGRESS_20);
+            } else if (progressRate <= 50) {
+                monthlyTaskProgress.put(date, PROGRESS_40);
+            } else if (progressRate <= 70) {
+                monthlyTaskProgress.put(date, PROGRESS_60);
+            } else if (progressRate <= 99) {
+                monthlyTaskProgress.put(date, PROGRESS_80);
+            } else {
+                monthlyTaskProgress.put(date, PROGRESS_100);
+            }
+        }
+
+        return monthlyTaskProgress;
+    }
+}

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
@@ -24,5 +24,20 @@ public interface RetrospectiveSkillRepository extends JpaRepository<Retrospectiv
             @Param("type") String type,
             Pageable pageable);
 
+    @Query("""
+           SELECT new com.trekker.domain.task.dto.SkillCountDto(rs.skill.name, COUNT(rs.skill.name))
+           FROM RetrospectiveSkill rs
+           JOIN rs.retrospective r
+           JOIN r.task t
+           JOIN t.project p
+           JOIN p.member m
+           WHERE m.id = :memberId AND rs.type = :type
+           GROUP BY rs.skill.name
+           ORDER BY COUNT(rs.skill.name) DESC
+           """)
+    List<SkillCountDto> findTopSkillsByMemberIdAndType(@Param("memberId") Long memberId,
+            @Param("type") String type,
+            Pageable pageable);
+
 
 }

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
@@ -39,18 +39,5 @@ public interface RetrospectiveSkillRepository extends JpaRepository<Retrospectiv
             @Param("type") String type,
             Pageable pageable);
 
-    @Query("""
-           SELECT new com.trekker.domain.task.dto.SkillCountDto(rs.skill.name, COUNT(rs.skill.name))
-           FROM RetrospectiveSkill rs
-           JOIN rs.retrospective r
-           JOIN r.task t
-           JOIN t.project p
-           JOIN p.member m
-           WHERE m.id = :memberId AND rs.type = :type
-           GROUP BY rs.skill.name
-           ORDER BY COUNT(rs.skill.name) DESC
-           """)
-    List<SkillCountDto> findSkillsByMemberIdAndType(@Param("memberId") Long memberId,
-            @Param("type") String type);
 
 }

--- a/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
+++ b/src/main/java/com/trekker/domain/retrospective/dao/RetrospectiveSkillRepository.java
@@ -39,5 +39,18 @@ public interface RetrospectiveSkillRepository extends JpaRepository<Retrospectiv
             @Param("type") String type,
             Pageable pageable);
 
+    @Query("""
+           SELECT new com.trekker.domain.task.dto.SkillCountDto(rs.skill.name, COUNT(rs.skill.name))
+           FROM RetrospectiveSkill rs
+           JOIN rs.retrospective r
+           JOIN r.task t
+           JOIN t.project p
+           JOIN p.member m
+           WHERE m.id = :memberId AND rs.type = :type
+           GROUP BY rs.skill.name
+           ORDER BY COUNT(rs.skill.name) DESC
+           """)
+    List<SkillCountDto> findSkillsByMemberIdAndType(@Param("memberId") Long memberId,
+            @Param("type") String type);
 
 }

--- a/src/main/java/com/trekker/domain/task/dao/TaskRepository.java
+++ b/src/main/java/com/trekker/domain/task/dao/TaskRepository.java
@@ -76,4 +76,20 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
                )
        """)
     List<Task> findTasksForToday(@Param("memberId") Long memberId, @Param("today") LocalDate today);
+
+
+    @Query("""
+           SELECT t
+           FROM Task t
+           JOIN FETCH t.project p
+           JOIN FETCH p.member m
+           LEFT JOIN FETCH t.retrospective
+           WHERE m.id =:memberId
+           AND (
+                (t.endDate IS NULL AND t.startDate BETWEEN :startOfMonth AND :endOfMonth) OR
+                (t.endDate IS NOT NULL AND t.endDate >=:startOfMonth AND t.startDate <= :endOfMonth)
+               )
+           """)
+    List<Task> findTasksInMonth(@Param("memberId") Long memberId, @Param("startOfMonth") LocalDate startOfMonth,
+    @Param("endOfMonth") LocalDate endOfMonth);
 }

--- a/src/test/java/com/trekker/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/trekker/domain/report/service/ReportServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class ReportServiceTest {
@@ -110,7 +111,7 @@ class ReportServiceTest {
     void getMemberSkillList() {
         // given
         String type = "하드";
-        when(retrospectiveSkillRepository.findSkillsByMemberIdAndType(memberId, type)).thenReturn(
+        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, type, Pageable.unpaged())).thenReturn(
                 mockHardSkillList);
 
         // when

--- a/src/test/java/com/trekker/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/trekker/domain/report/service/ReportServiceTest.java
@@ -1,0 +1,123 @@
+package com.trekker.domain.report.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.trekker.domain.report.dto.ReportResDto;
+import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
+import com.trekker.domain.task.dao.TaskRepository;
+import com.trekker.domain.task.dto.SkillCountDto;
+import com.trekker.domain.task.entity.Task;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @InjectMocks
+    ReportService reportService;
+    @Mock
+    private RetrospectiveSkillRepository retrospectiveSkillRepository;
+    @Mock
+    private TaskRepository taskRepository;
+
+    private Long memberId;
+    private List<SkillCountDto> mockSoftSkillList;
+    private List<SkillCountDto> mockHardSkillList;
+    private LocalDate today;
+    private Task task1;
+    private Task task2;
+
+    @BeforeEach
+    void setUp() {
+        memberId = 1L;
+        today = LocalDate.now();
+
+        mockSoftSkillList = Arrays.asList(
+                new SkillCountDto("Communication", 5L),
+                new SkillCountDto("Teamwork", 4L),
+                new SkillCountDto("Adaptability", 3L)
+        );
+
+        mockHardSkillList = Arrays.asList(
+                new SkillCountDto("Java", 6L),
+                new SkillCountDto("Spring Boot", 4L),
+                new SkillCountDto("SQL", 3L),
+                new SkillCountDto("Spring", 2L)
+        );
+
+        task1 = Task.builder()
+                .id(1L)
+                .name("미완료 할 일")
+                .isCompleted(false)
+                .start_date(today)
+                .build();
+
+        task2 = Task.builder()
+                .id(2L)
+                .name("완료 할 일")
+                .isCompleted(true)
+                .start_date(today)
+                .end_date(today.plusDays(3))
+                .build();
+    }
+
+
+    @DisplayName("회원의 리포트를 조회합니다.")
+    @Test
+    void getMemberReport() {
+        // given
+        LocalDate startOfMonth = LocalDate.of(today.getYear(), today.getMonth(), 1);
+        LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
+
+        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, "소프트",
+                PageRequest.of(0, 3))).thenReturn(mockSoftSkillList);
+        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, "하드",
+                PageRequest.of(0, 3))).thenReturn(mockHardSkillList);
+        when(taskRepository.findTasksInMonth(memberId, startOfMonth, endOfMonth)).thenReturn(
+                List.of(task1, task2));
+
+        // when
+        ReportResDto memberReport = reportService.getMemberReport(memberId);
+
+        // then
+        assertThat(memberReport.softSkillList()).isEqualTo(mockSoftSkillList);
+        assertThat(memberReport.hardSkillList()).isEqualTo(mockHardSkillList);
+
+
+        // 오늘의 경우 할 일 2개중 1개만 완료 50% -> 40
+        assertThat(memberReport.dailyProgressRatesInMonth().get(today)).isEqualTo(40);
+        assertThat(memberReport.dailyProgressRatesInMonth().get(today.plusDays(1))).isEqualTo(100);
+        // 오늘 완료한 할일은 1개(task2)
+        assertThat(memberReport.weeklyCompletedTasks().get(today)).isEqualTo(1);
+
+    }
+
+    @DisplayName("회원의 전체 스킬 리스트를 조회합니다.")
+    @Test
+    void getMemberSkillList() {
+        // given
+        String type = "하드";
+        when(retrospectiveSkillRepository.findSkillsByMemberIdAndType(memberId, type)).thenReturn(
+                mockHardSkillList);
+
+        // when
+        List<SkillCountDto> memberSkillList = reportService.getMemberSkillList(memberId, type);
+
+        // then
+        assertThat(memberSkillList).isEqualTo(mockHardSkillList);
+        assertThat(memberSkillList.size()).isEqualTo(4);
+    }
+}

--- a/src/test/java/com/trekker/domain/report/util/ProgressRateCalculatorTest.java
+++ b/src/test/java/com/trekker/domain/report/util/ProgressRateCalculatorTest.java
@@ -1,0 +1,51 @@
+package com.trekker.domain.report.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ProgressRateCalculatorTest {
+
+    @DisplayName("월별 작업 진행률 계산 테스트")
+    @ParameterizedTest(name = "date={0}, totalTasks={1}, completedTasks={2}, expectedProgress={3}")
+    @MethodSource("provideProgressRateTestCases")
+    void calculateProgressRate(LocalDate date, int totalTasks, int completedTasks, int expectedProgress) {
+        // given
+        Map<LocalDate, Map<String, Integer>> input = Map.of(
+                date, Map.of(
+                        "totalTasks", totalTasks,
+                        "completedTasks", completedTasks
+                )
+        );
+
+        // when
+        Map<LocalDate, Integer> result = ProgressRateCalculator.calculateProgressRate(input);
+
+        // then
+        assertThat(result).containsEntry(date, expectedProgress);
+    }
+
+    static Stream<Arguments> provideProgressRateTestCases() {
+        return Stream.of(
+                // 완료된 작업이 없는 경우
+                Arguments.of(LocalDate.of(2024, 12, 1), 10, 0, 0),
+                // 진행률이 30 이하인 경우
+                Arguments.of(LocalDate.of(2024, 12, 2), 10, 3, 20),
+                // 진행률이 50 이하인 경우
+                Arguments.of(LocalDate.of(2024, 12, 3), 10, 5, 40),
+                // 진행률이 70 이하인 경우
+                Arguments.of(LocalDate.of(2024, 12, 4), 10, 7, 60),
+                // 진행률이 99 이하인 경우
+                Arguments.of(LocalDate.of(2024, 12, 5), 10, 9, 80),
+                // 진행률이 100인 경우
+                Arguments.of(LocalDate.of(2024, 12, 6), 10, 10, 100)
+        );
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue
close: #17 

## 📝 Description
회원 리포트 조회 기능을 구현했습니다.
회원 리포트 조회시
- 상위 3개의 소프트 스킬
- 상위 3개의 하드 스킬
- 이번 달 날짜별 진행률
   - 진행률 = `완료한 할 일` / `전체 할일` 
     - 1% ~ 30%는 `20%`, 31% ~ 50%는 `40%`, 51% ~ 70%는 `60%`, 71% ~ 99%는 `80%` , `100%` 
- 이번 주(저번주 일부터 이번주 토) 완료한 할 일 수 
를 반환합니다.

추가로 소프트/하드 스킬별 전체 조회 및 반환하는 기능도 구현했습니다.

## ⭐️ Review
