### PR TITLE
Chanbyoung/feature/#27 구글 로그인 방식 별도 추가

### DIFF
--- a/src/main/java/com/trekker/domain/member/api/MemberController.java
+++ b/src/main/java/com/trekker/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package com.trekker.domain.member.api;
 
 import com.trekker.domain.member.api.docs.MemberApi;
 import com.trekker.domain.member.application.MemberService;
+import com.trekker.domain.member.dto.req.MemberFeedbackReqDto;
 import com.trekker.domain.member.dto.req.MemberUpdateReqDto;
 import com.trekker.domain.member.dto.req.OnboardingReqDto;
 import com.trekker.domain.member.dto.res.MemberPortfolioResDto;
@@ -50,5 +51,14 @@ public class MemberController implements MemberApi {
     public ResponseEntity<MemberPortfolioResDto> getPortfolio(@LoginMember Long memberId) {
         MemberPortfolioResDto portfolio = memberService.getPortfolio(memberId);
         return ResponseEntity.ok(portfolio);
+    }
+
+    @PostMapping("/feedback")
+    public ResponseEntity<Void> saveFeedback(
+            @LoginMember Long memberId,
+            @RequestBody MemberFeedbackReqDto feedbackReqDto
+    ) {
+        memberService.saveFeedBack(memberId, feedbackReqDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/trekker/domain/member/api/docs/MemberApi.java
+++ b/src/main/java/com/trekker/domain/member/api/docs/MemberApi.java
@@ -1,5 +1,6 @@
 package com.trekker.domain.member.api.docs;
 
+import com.trekker.domain.member.dto.req.MemberFeedbackReqDto;
 import com.trekker.domain.member.dto.req.MemberUpdateReqDto;
 import com.trekker.domain.member.dto.req.OnboardingReqDto;
 import com.trekker.domain.member.dto.res.MemberPortfolioResDto;
@@ -73,5 +74,18 @@ public interface MemberApi {
     })
     ResponseEntity<MemberPortfolioResDto> getPortfolio(
             @Parameter(hidden = true) Long memberId
+    );
+
+    @Operation(
+            summary = "회원 피드백 저장",
+            description = "회원의 피드백을 저장합니다.",
+            security = @SecurityRequirement(name = "BearerAuth" )
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "회원 피드백 저장 성공" )
+    })
+    ResponseEntity<Void> saveFeedback(
+            @Parameter(hidden = true) Long memberId,
+            MemberFeedbackReqDto memberFeedbackReqDto
     );
 }

--- a/src/main/java/com/trekker/domain/member/application/MemberService.java
+++ b/src/main/java/com/trekker/domain/member/application/MemberService.java
@@ -2,12 +2,15 @@ package com.trekker.domain.member.application;
 
 import static java.util.stream.Collectors.toList;
 
+import com.trekker.domain.member.dao.MemberFeedbackRepository;
 import com.trekker.domain.member.dao.MemberRepository;
+import com.trekker.domain.member.dto.req.MemberFeedbackReqDto;
 import com.trekker.domain.member.dto.req.MemberUpdateReqDto;
 import com.trekker.domain.member.dto.req.OnboardingReqDto;
 import com.trekker.domain.member.dto.res.MemberPortfolioResDto;
 import com.trekker.domain.member.dto.res.MemberResDto;
 import com.trekker.domain.member.entity.Member;
+import com.trekker.domain.member.entity.MemberFeedback;
 import com.trekker.domain.project.dto.ProjectSkillDto;
 import com.trekker.domain.project.dto.res.ProjectSkillResDto;
 import com.trekker.domain.retrospective.dao.RetrospectiveSkillRepository;
@@ -34,6 +37,7 @@ public class MemberService {
     private final FileService fileService;
     private final MemberRepository memberRepository;
     private final RetrospectiveSkillRepository retrospectiveSkillRepository;
+    private final MemberFeedbackRepository memberFeedbackRepository;
 
     /**
      * 회원의 정보를 조회합니다
@@ -102,6 +106,15 @@ public class MemberService {
 
         // 회원 정보와 프로젝트 데이터를 기반으로 포트폴리오 생성
         return MemberPortfolioResDto.toDto(member, projectSkillResDto);
+    }
+
+    @Transactional
+    public void saveFeedBack(Long memberId, MemberFeedbackReqDto feedbackReqDto) {
+        Member member = findByIdWithJob(memberId);
+
+        MemberFeedback memberFeedback = feedbackReqDto.toEntity(member);
+
+        memberFeedbackRepository.save(memberFeedback);
     }
 
 

--- a/src/main/java/com/trekker/domain/member/application/MemberService.java
+++ b/src/main/java/com/trekker/domain/member/application/MemberService.java
@@ -28,8 +28,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional(readOnly = true)
 public class MemberService {
 
-    private static final String SOFT_SKILL = "소프트";
-    private static final String HARD_SKILL = "하드";
+    private static final String SOFT_SKILL = "soft";
+    private static final String HARD_SKILL = "hard";
 
     private final FileService fileService;
     private final MemberRepository memberRepository;

--- a/src/main/java/com/trekker/domain/member/dao/MemberFeedbackRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberFeedbackRepository.java
@@ -3,6 +3,6 @@ package com.trekker.domain.member.dao;
 import com.trekker.domain.member.entity.MemberFeedback;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberFeedbackRepository extends JpaRepository<MemberFeedback, Long>{
+public interface MemberFeedbackRepository extends JpaRepository<MemberFeedback, Long> {
 
 }

--- a/src/main/java/com/trekker/domain/member/dao/MemberFeedbackRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberFeedbackRepository.java
@@ -1,0 +1,8 @@
+package com.trekker.domain.member.dao;
+
+import com.trekker.domain.member.entity.MemberFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberFeedbackRepository extends JpaRepository<MemberFeedback, Long>{
+
+}

--- a/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/trekker/domain/member/dao/MemberRepository.java
@@ -31,6 +31,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
            SELECT m
            FROM Member m
            LEFT JOIN FETCH m.job
+           LEFT JOIN FETCH m.socialProvider
            WHERE m.id =:memberId
            """)
     Optional<Member> findByIdWithJob(@Param("memberId") Long memberId);

--- a/src/main/java/com/trekker/domain/member/dto/req/MemberFeedbackReqDto.java
+++ b/src/main/java/com/trekker/domain/member/dto/req/MemberFeedbackReqDto.java
@@ -1,0 +1,19 @@
+package com.trekker.domain.member.dto.req;
+
+import com.trekker.domain.member.entity.Member;
+import com.trekker.domain.member.entity.MemberFeedback;
+import jakarta.validation.constraints.Size;
+
+public record MemberFeedbackReqDto(
+        @Size(max = 100)
+        String content
+) {
+
+    public MemberFeedback toEntity(Member member) {
+        return MemberFeedback.builder()
+                .content(content)
+                .member(member)
+                .build();
+    }
+
+}

--- a/src/main/java/com/trekker/domain/member/dto/req/MemberWithdrawalReqDto.java
+++ b/src/main/java/com/trekker/domain/member/dto/req/MemberWithdrawalReqDto.java
@@ -6,6 +6,8 @@ import com.trekker.domain.member.entity.MemberWithdrawalFeedback;
 // 탈퇴 시 필요로 하는 요청 값(피드백)을 담는 DTO
 public record MemberWithdrawalReqDto(
 
+        String accessToken,
+
         String feedback,
 
         String reason

--- a/src/main/java/com/trekker/domain/member/dto/res/MemberResDto.java
+++ b/src/main/java/com/trekker/domain/member/dto/res/MemberResDto.java
@@ -10,6 +10,8 @@ public record MemberResDto(
 
         String jobName,
 
+        String provider,
+
         String profileImage
 ) {
 
@@ -17,6 +19,7 @@ public record MemberResDto(
         return MemberResDto.builder()
                 .name(member.getName())
                 .jobName(member.getJob().getJobName())
+                .provider(member.getSocialProvider().getProvider())
                 .profileImage(member.getProfileImage())
                 .build();
     }

--- a/src/main/java/com/trekker/domain/member/entity/MemberFeedback.java
+++ b/src/main/java/com/trekker/domain/member/entity/MemberFeedback.java
@@ -1,0 +1,43 @@
+package com.trekker.domain.member.entity;
+
+import com.trekker.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "member_feedbacks")
+public class MemberFeedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_feedback_id", nullable = false)
+    private Long id;
+
+    // 피드백 내용
+    @Column(name = "content", length = 100)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public MemberFeedback(Long id, String content, Member member) {
+        this.id = id;
+        this.content = content;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/trekker/domain/project/application/ProjectService.java
+++ b/src/main/java/com/trekker/domain/project/application/ProjectService.java
@@ -34,8 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ProjectService {
 
-    private static final String SOFT_SKILL = "소프트";
-    private static final String HARD_SKILL = "하드";
+    private static final String SOFT_SKILL = "soft";
+    private static final String HARD_SKILL = "hard";
 
     private final ProjectRepository projectRepository;
     private final TaskRepository taskRepository;

--- a/src/main/java/com/trekker/domain/report/service/ReportService.java
+++ b/src/main/java/com/trekker/domain/report/service/ReportService.java
@@ -24,8 +24,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ReportService {
 
-    private static final String SOFT_SKILL = "소프트";
-    private static final String HARD_SKILL = "하드";
+    private static final String SOFT_SKILL = "soft";
+    private static final String HARD_SKILL = "hard";
     private static final String TOTAL_TASK = "totalTasks";
     private static final String COMPLETED_TASK = "completedTasks";
 

--- a/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
+++ b/src/main/java/com/trekker/domain/retrospective/application/RetrospectiveService.java
@@ -24,8 +24,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class RetrospectiveService {
 
-    private static final String SOFT_SKILL = "소프트";
-    private static final String HARD_SKILL = "하드";
+    private static final String SOFT_SKILL = "soft";
+    private static final String HARD_SKILL = "hard";
 
 
     private final RetrospectiveRepository retrospectiveRepository;

--- a/src/main/java/com/trekker/domain/task/application/TaskService.java
+++ b/src/main/java/com/trekker/domain/task/application/TaskService.java
@@ -25,8 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class TaskService {
 
-    private static final int TASK_RANGE_DAYS = 3;
-
     private final TaskRepository taskRepository;
     private final ProjectRepository projectRepository;
 

--- a/src/main/java/com/trekker/domain/task/application/TaskService.java
+++ b/src/main/java/com/trekker/domain/task/application/TaskService.java
@@ -11,7 +11,9 @@ import com.trekker.domain.task.entity.Task;
 import com.trekker.domain.task.util.TaskFilter;
 import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -50,16 +52,17 @@ public class TaskService {
      * @param memberId  사용자의 id
      * @param projectId 조회할 프로젝트의 Id.
      * @param reqDate   기준 날짜
-     * @return ProjectWithTaskInfoResDto - 프로젝트 정보와 함께 기준 날짜의 태스크 목록, ±3일 내 완료 상태를 포함.
+     * @return ProjectWithTaskInfoResDto - 프로젝트 정보와 함께 기준 날짜의 태스크 목록, 기간 내 완료 상태를 포함.
      */
     public ProjectWithTaskInfoResDto getTaskList(Long memberId, Long projectId, LocalDate reqDate) {
         // 프로젝트 정보 조회 및 사용자 검증
         Project project = findProjectByIdWithMember(projectId);
         project.validateOwner(memberId);
 
-        // +-3일 범위 계산
-        LocalDate startDate = reqDate.minusDays(TASK_RANGE_DAYS);
-        LocalDate endDate = reqDate.plusDays(TASK_RANGE_DAYS);
+        // 현재 날짜를 기준으로 저번 주 일요일과 이번 주 토요일 계산
+        LocalDate now = LocalDate.now();
+        LocalDate startDate = now.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
+        LocalDate endDate = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
 
         // 태스크 데이터 조회
         List<Task> tasksInRange = taskRepository.findTasksWithinDateRange(projectId, startDate, endDate);

--- a/src/main/java/com/trekker/global/auth/api/AuthController.java
+++ b/src/main/java/com/trekker/global/auth/api/AuthController.java
@@ -5,18 +5,22 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import com.trekker.domain.member.dto.req.MemberWithdrawalReqDto;
 import com.trekker.global.auth.api.docs.AuthApi;
 import com.trekker.global.auth.application.AuthService;
+import com.trekker.global.auth.dto.req.GoogleLoginReqDto;
 import com.trekker.global.auth.dto.req.RefreshTokenReqDto;
 import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.auth.dto.res.GoogleRes;
 import com.trekker.global.auth.dto.res.RefreshTokenResDto;
 import com.trekker.global.config.security.annotation.LoginMember;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@Slf4j
 public class AuthController implements AuthApi {
 
     private final AuthService authService;
@@ -67,6 +71,14 @@ public class AuthController implements AuthApi {
     ) {
         AuthResDto authResponse = authService.retrieveAuthResponse(tempToken);
         return ResponseEntity.ok(authResponse);
+    }
+
+    @PostMapping("/google/login")
+    public ResponseEntity<GoogleRes> loginWithGoogle(@RequestBody GoogleLoginReqDto request) {
+        log.info("request ={} ", request);
+        GoogleRes googleRes = authService.authenticateGoogleUser(request);
+
+        return ResponseEntity.ok(googleRes);
     }
 
     private String resolveToken(String accessToken) {

--- a/src/main/java/com/trekker/global/auth/api/docs/AuthApi.java
+++ b/src/main/java/com/trekker/global/auth/api/docs/AuthApi.java
@@ -1,8 +1,10 @@
 package com.trekker.global.auth.api.docs;
 
 import com.trekker.domain.member.dto.req.MemberWithdrawalReqDto;
+import com.trekker.global.auth.dto.req.GoogleLoginReqDto;
 import com.trekker.global.auth.dto.req.RefreshTokenReqDto;
 import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.auth.dto.res.GoogleRes;
 import com.trekker.global.auth.dto.res.RefreshTokenResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,19 +21,19 @@ public interface AuthApi {
     @Operation(
             summary = "로그아웃",
             description = "사용자가 로그아웃합니다.",
-            security = @SecurityRequirement(name = "BearerAuth" )
+            security = @SecurityRequirement(name = "BearerAuth")
     )
-    @ApiResponse(responseCode = "204", description = "로그아웃 성공" )
+    @ApiResponse(responseCode = "204", description = "로그아웃 성공")
     ResponseEntity<Void> logout(
-            @Parameter(description = "엑세스 토큰", example = "Bearer eyJhbGci..." ) String accessToken
+            @Parameter(description = "엑세스 토큰", example = "Bearer eyJhbGci...") String accessToken
     );
 
     @Operation(
             summary = "회원 탈퇴",
             description = "사용자가 계정을 삭제합니다.",
-            security = @SecurityRequirement(name = "BearerAuth" )
+            security = @SecurityRequirement(name = "BearerAuth")
     )
-    @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공" )
+    @ApiResponse(responseCode = "204", description = "회원 탈퇴 성공")
     ResponseEntity<Void> deleteAccount(
             @Parameter(hidden = true) Long id,
             MemberWithdrawalReqDto reqDto
@@ -41,14 +43,14 @@ public interface AuthApi {
             summary = "엑세스 토큰 재발급",
             description = "리프레시 토큰을 통해 새로운 엑세스 토큰을 재발급합니다."
     )
-    @ApiResponse(responseCode = "200", description = "엑세스 토큰 재발급 성공" )
+    @ApiResponse(responseCode = "200", description = "엑세스 토큰 재발급 성공")
     ResponseEntity<AuthResDto> refreshAccessToken(RefreshTokenReqDto refreshTokenRequestDto);
 
     @Operation(
             summary = "리프레시 토큰 재발급",
             description = "만료된 리프레시 토큰을 재발급합니다."
     )
-    @ApiResponse(responseCode = "200", description = "리프레시 토큰 재발급 성공" )
+    @ApiResponse(responseCode = "200", description = "리프레시 토큰 재발급 성공")
     ResponseEntity<RefreshTokenResDto> reissueRefreshToken(
             RefreshTokenReqDto refreshTokenRequestDto);
 
@@ -56,8 +58,17 @@ public interface AuthApi {
             summary = "최종 토큰 발급",
             description = "임시 토큰을 검증하고 최종 엑세스 및 리프레시 토큰을 발급합니다."
     )
-    @ApiResponse(responseCode = "200", description = "최종 토큰 발급 성공" )
+    @ApiResponse(responseCode = "200", description = "최종 토큰 발급 성공")
     ResponseEntity<AuthResDto> issueFinalTokens(
-            @Parameter(description = "임시 토큰", example = "tempToken12345" ) @NotNull String tempToken
+            @Parameter(description = "임시 토큰", example = "tempToken12345") @NotNull String tempToken
+    );
+
+    @Operation(
+            summary = "구글 로그인 및 토큰 발급",
+            description = "구글 로그인 후 최종 토큰을 발급합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "구글 로그인 성공")
+    ResponseEntity<GoogleRes> loginWithGoogle(
+            GoogleLoginReqDto googleLoginReqDto
     );
 }

--- a/src/main/java/com/trekker/global/auth/application/AuthService.java
+++ b/src/main/java/com/trekker/global/auth/application/AuthService.java
@@ -4,7 +4,11 @@ import com.trekker.domain.member.dao.MemberRepository;
 import com.trekker.domain.member.dao.MemberWithdrawalFeedbackRepository;
 import com.trekker.domain.member.dto.req.MemberWithdrawalReqDto;
 import com.trekker.domain.member.entity.Member;
+import com.trekker.global.auth.custom.CustomUserDetails;
+import com.trekker.global.auth.custom.CustomUserDetailsService;
+import com.trekker.global.auth.dto.req.GoogleLoginReqDto;
 import com.trekker.global.auth.dto.res.AuthResDto;
+import com.trekker.global.auth.dto.res.GoogleRes;
 import com.trekker.global.auth.dto.res.RefreshTokenResDto;
 import com.trekker.global.config.redis.dao.RedisRepository;
 import com.trekker.global.config.security.TokenProvider;
@@ -12,6 +16,14 @@ import com.trekker.global.exception.custom.BusinessException;
 import com.trekker.global.exception.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +38,9 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final RedisRepository redisRepository;
     private final UnlinkService unlinkService;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final GoogleTokenValidator googleTokenValidator;
 
 
     @Transactional
@@ -94,9 +109,106 @@ public class AuthService {
         feedbackRepository.save(reqDto.toEntity(member));
 
         // 소셜 언링크 (연결 끊기)
-        unlinkService.unlink(member);
+        unlinkService.unlink(member, reqDto);
 
         // 회원 삭제
         member.markAsDeleted();
+    }
+
+    /**
+     * 구글 로그인을 직접 수행합니다.
+     * @param request 구글 사용자 정보 및 엑세스 토큰을 담고있는 dto
+     * @return 자체 발급한 토큰과 온보딩 완료 여부를 포함한 dto
+     */
+    @Transactional
+    public GoogleRes authenticateGoogleUser(GoogleLoginReqDto request) {
+        // 1. Google Access Token 검증
+        validateGoogleAccessToken(request.accessToken());
+
+        // 2. OAuth2UserRequest 생성
+        OAuth2UserRequest userRequest = createOAuth2UserRequest(request.accessToken());
+
+        // 3. 사용자 정보 로드 및 Authentication 생성
+        Authentication authentication = createAuthentication(userRequest);
+
+        // 4. SecurityContext에 Authentication 설정
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 5. JWT 생성 및 최종 응답 반환
+        return createGoogleResponse(authentication);
+    }
+
+    /**
+     * Google Access Token의 유효성을 검증합니다.
+     *
+     * @param accessToken Google Access Token
+     * @throws IllegalArgumentException 유효하지 않은 토큰일 경우 예외를 발생시킵니다.
+     */
+    private void validateGoogleAccessToken(String accessToken) {
+        boolean googleTokenValid = googleTokenValidator.validateAccessToken(accessToken);
+        if (!googleTokenValid) {
+            throw new IllegalArgumentException("유효하지 않은 Google Access Token입니다.");
+        }
+    }
+
+    /**
+     * Google Access Token을 기반으로 OAuth2UserRequest를 생성합니다.
+     *
+     * @param accessToken Google Access Token
+     * @return OAuth2UserRequest OAuth2 사용자 요청 객체
+     * @throws IllegalStateException Google 클라이언트 설정을 찾을 수 없을 경우 예외를 발생시킵니다.
+     */
+    private OAuth2UserRequest createOAuth2UserRequest(String accessToken) {
+        ClientRegistration registration = clientRegistrationRepository.findByRegistrationId("google");
+        if (registration == null) {
+            throw new IllegalStateException("Google 클라이언트 설정을 찾을 수 없습니다.");
+        }
+
+        OAuth2AccessToken token = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                accessToken,
+                null,
+                null
+        );
+
+        return new OAuth2UserRequest(registration, token);
+    }
+
+    /**
+     * OAuth2UserRequest를 기반으로 사용자 정보를 로드하고 Authentication 객체를 생성합니다.
+     *
+     * @param userRequest OAuth2 사용자 요청 객체
+     * @return Authentication 인증 객체
+     */
+    private Authentication createAuthentication(OAuth2UserRequest userRequest) {
+        // CustomUserDetailsService를 이용하여 OAuth2 사용자 정보를 로드합니다.
+        OAuth2User oAuth2User = customUserDetailsService.loadUser(userRequest);
+
+        // 로드된 사용자 정보를 CustomUserDetails로 변환합니다.
+        CustomUserDetails userDetails = (CustomUserDetails) oAuth2User;
+
+        // Authentication 객체를 생성하여 반환합니다.
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+    }
+
+    /**
+     * Authentication 객체를 기반으로 JWT를 생성하고 최종 응답 객체를 생성합니다.
+     *
+     * @param authentication 인증 객체
+     * @return GoogleRes 최종 응답 객체
+     */
+    private GoogleRes createGoogleResponse(Authentication authentication) {
+        // JWT를 생성합니다.
+        AuthResDto authResponse = tokenProvider.createAuthResponse(authentication);
+
+        // 사용자 정보를 CustomUserDetails로 변환합니다.
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        // JWT와 사용자 설정 완료 여부를 포함한 GoogleRes 응답 객체를 반환합니다.
+        return new GoogleRes(authResponse, userDetails.getIsCompleted());
     }
 }

--- a/src/main/java/com/trekker/global/auth/application/AuthService.java
+++ b/src/main/java/com/trekker/global/auth/application/AuthService.java
@@ -147,7 +147,7 @@ public class AuthService {
     private void validateGoogleAccessToken(String accessToken) {
         boolean googleTokenValid = googleTokenValidator.validateAccessToken(accessToken);
         if (!googleTokenValid) {
-            throw new IllegalArgumentException("유효하지 않은 Google Access Token입니다.");
+            throw new BusinessException("accessToken", accessToken, ErrorCode.BAD_REQUEST);
         }
     }
 
@@ -161,7 +161,7 @@ public class AuthService {
     private OAuth2UserRequest createOAuth2UserRequest(String accessToken) {
         ClientRegistration registration = clientRegistrationRepository.findByRegistrationId("google");
         if (registration == null) {
-            throw new IllegalStateException("Google 클라이언트 설정을 찾을 수 없습니다.");
+            throw new BusinessException("accessToken", accessToken, ErrorCode.BAD_REQUEST);
         }
 
         OAuth2AccessToken token = new OAuth2AccessToken(

--- a/src/main/java/com/trekker/global/auth/application/GoogleTokenValidator.java
+++ b/src/main/java/com/trekker/global/auth/application/GoogleTokenValidator.java
@@ -1,0 +1,39 @@
+package com.trekker.global.auth.application;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleTokenValidator {
+
+    private static final String GOOGLE_TOKEN_INFO_URL = "https://www.googleapis.com/oauth2/v3/tokeninfo";
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String GOOGLE_CLIENT_KEY;
+
+    private final RestTemplate restTemplate;
+
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            String url = GOOGLE_TOKEN_INFO_URL + "?access_token=" + accessToken;
+
+            // Google의 토큰 정보 가져오기
+            ResponseEntity<Map> response = restTemplate.getForEntity(url, Map.class);
+
+            // 토큰 검증 로직 추가 (예: audience, expires_in 확인)
+            Map<String, Object> tokenInfo = response.getBody();
+            if (tokenInfo != null && GOOGLE_CLIENT_KEY.equals(tokenInfo.get("aud"))) {
+                return true; // 토큰이 유효하고 클라이언트 ID와 일치함
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/trekker/global/auth/dto/req/GoogleLoginReqDto.java
+++ b/src/main/java/com/trekker/global/auth/dto/req/GoogleLoginReqDto.java
@@ -1,0 +1,9 @@
+package com.trekker.global.auth.dto.req;
+
+public record GoogleLoginReqDto(
+        String email,
+        String googleId,
+        String accessToken
+) {
+
+}

--- a/src/main/java/com/trekker/global/auth/dto/res/GoogleRes.java
+++ b/src/main/java/com/trekker/global/auth/dto/res/GoogleRes.java
@@ -1,0 +1,8 @@
+package com.trekker.global.auth.dto.res;
+
+public record GoogleRes(
+        AuthResDto authResDto,
+        boolean isCompleted
+) {
+
+}

--- a/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
+++ b/src/main/java/com/trekker/global/config/redis/dao/RedisRepository.java
@@ -19,8 +19,6 @@ public class RedisRepository {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private static final int TEMP_TOKEN_EXPIRATION = 300;
-    private static final int SOCIAL_REFRESH_TOKEN_EXPIRATION = 3650;
-    private static final String SOCIAL_TOKEN_REDIS_KEY = "social:refreshToken_";
 
     /**
      * Refresh 토큰과 사용자 정보를 Redis에 저장
@@ -104,34 +102,6 @@ public class RedisRepository {
             return authResponse;
         } catch (Exception e) {
             log.warn("Redis에서 임시 토큰 조회 실패: {}", e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * 소셜 Refresh Token 저장
-     */
-    public void storeSocialRefreshTokenWithExtendedTTL(String userAccount, String refreshToken) {
-        try {
-            String redisKey = SOCIAL_TOKEN_REDIS_KEY + userAccount;
-            redisTemplate.opsForValue()
-                    .set(redisKey, refreshToken, SOCIAL_REFRESH_TOKEN_EXPIRATION, TimeUnit.DAYS);
-        } catch (Exception e) {
-            log.warn("Redis에 소셜 Refresh Token 저장 실패: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * 소셜 Refresh Token 조회 및 삭제
-     */
-    public String fetchAndDeleteSocialRefreshToken(String userAccount) {
-        try {
-            String redisKey = SOCIAL_TOKEN_REDIS_KEY + userAccount;
-            String refreshToken = (String) redisTemplate.opsForValue().get(redisKey);
-            redisTemplate.delete(redisKey);
-            return refreshToken;
-        } catch (Exception e) {
-            log.warn("Redis에서 소셜 Refresh Token 조회 실패: {}", e.getMessage());
             return null;
         }
     }

--- a/src/main/java/com/trekker/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/trekker/global/config/security/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
                                         "/api/v1/auth/access/refresh",
                                         "/api/v1/auth/refresh/reissue",
                                         "/api/v1/auth/issue-final-token",
+                                        "/api/v1/auth/google/login",
                                         "/uploads/profile-images/**",
                                         "/login/oauth2/**",
                                         "/oauth2/**",

--- a/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
@@ -38,7 +38,7 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws IOException {
         CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
-        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
+//        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
 
         // 최종 액세스 및 리프레시 토큰 생성
         AuthResDto authResponse = tokenProvider.createAuthResponse(authentication);
@@ -48,7 +48,7 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         String account = oAuth2User.getId();
 
         // 제공자가 google일 경우, 추후 회원 탈퇴를 위한 리프래시 토큰 저장
-        handleGoogleRefreshToken(authToken, account);
+//        handleGoogleRefreshToken(authToken, account);
 
         // 성공 URL에 쿼리 파라미터로 임시 토큰과 isGuest 정보를 전달
         String redirectUrl = UriComponentsBuilder.fromUriString(SUCCESS_URL)

--- a/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
+++ b/src/main/java/com/trekker/global/config/security/handler/CustomLoginSuccessHandler.java
@@ -10,9 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -23,9 +20,6 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
 
-    private final TokenProvider tokenProvider;
-    private final RedisRepository redisRepository;
-    private final OAuth2AuthorizedClientService authorizedClientService;
     private static final String TEMP_TOKEN_NAME = "tempToken";
     private static final String USER_ACCOUNT = "account";
     private static final String IS_COMPLETED = "isCompleted";
@@ -33,12 +27,14 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
     @Value("${login.success-url}")
     private String SUCCESS_URL;
 
+    private final TokenProvider tokenProvider;
+    private final RedisRepository redisRepository;
+
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
             Authentication authentication) throws IOException {
         CustomUserDetails oAuth2User = (CustomUserDetails) authentication.getPrincipal();
-//        OAuth2AuthenticationToken authToken = (OAuth2AuthenticationToken) authentication;
 
         // 최종 액세스 및 리프레시 토큰 생성
         AuthResDto authResponse = tokenProvider.createAuthResponse(authentication);
@@ -46,9 +42,6 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         // Redis에 authResponse 저장 및 임시 토큰 발급
         String tempToken = redisRepository.storeAuthResponseWithTempToken(authResponse);
         String account = oAuth2User.getId();
-
-        // 제공자가 google일 경우, 추후 회원 탈퇴를 위한 리프래시 토큰 저장
-//        handleGoogleRefreshToken(authToken, account);
 
         // 성공 URL에 쿼리 파라미터로 임시 토큰과 isGuest 정보를 전달
         String redirectUrl = UriComponentsBuilder.fromUriString(SUCCESS_URL)
@@ -60,33 +53,4 @@ public class CustomLoginSuccessHandler implements AuthenticationSuccessHandler {
         response.sendRedirect(redirectUrl); // 프론트엔드로 리다이렉트
     }
 
-    /**
-     * Google 소셜 Refresh Token 저장 처리
-     */
-    private void handleGoogleRefreshToken(OAuth2AuthenticationToken authToken, String account) {
-        if (authToken.getAuthorizedClientRegistrationId().equals("google")) {
-            String socialRefreshToken = fetchGoogleRefreshToken(authToken);
-            if (socialRefreshToken != null) {
-                redisRepository.storeSocialRefreshTokenWithExtendedTTL(account, socialRefreshToken);
-                log.info("Google Refresh Token 저장 완료: {}", socialRefreshToken);
-            } else {
-                log.warn("Google Refresh Token을 가져오지 못했습니다. account={}", account);
-            }
-        }
-    }
-
-    /**
-     * Google Refresh Token을 가져오는 메서드
-     */
-    private String fetchGoogleRefreshToken(OAuth2AuthenticationToken authToken) {
-        // Spring Security에서 OAuth2AuthorizedClient 가져오기
-        OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
-                authToken.getAuthorizedClientRegistrationId(),
-                authToken.getName());
-
-        if (client != null && client.getRefreshToken() != null) {
-            return client.getRefreshToken().getTokenValue();
-        }
-        return null;
-    }
 }

--- a/src/test/java/com/trekker/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/trekker/domain/member/application/MemberServiceTest.java
@@ -63,7 +63,7 @@ class MemberServiceTest {
                 .projectDescription("project1")
                 .startDate(LocalDate.now())
                 .endDate(LocalDate.now().plusDays(10))
-                .skillType("소프트")
+                .skillType("soft")
                 .skillName("Communication")
                 .skillCount(5L)
                 .build();
@@ -74,7 +74,7 @@ class MemberServiceTest {
                 .projectDescription("project2")
                 .startDate(LocalDate.now())
                 .endDate(LocalDate.now().plusDays(10))
-                .skillType("소프트")
+                .skillType("soft")
                 .skillName("Communication")
                 .skillCount(5L)
                 .build();
@@ -85,7 +85,7 @@ class MemberServiceTest {
                 .projectDescription("project2")
                 .startDate(LocalDate.now())
                 .endDate(LocalDate.now().plusDays(10))
-                .skillType("하드")
+                .skillType("hard")
                 .skillName("Spring Boot")
                 .skillCount(5L)
                 .build();

--- a/src/test/java/com/trekker/domain/project/application/ProjectServiceTest.java
+++ b/src/test/java/com/trekker/domain/project/application/ProjectServiceTest.java
@@ -152,9 +152,9 @@ class ProjectServiceTest {
 
         doNothing().when(mockProject).validateOwner(memberId);
         when(projectRepository.findProjectByIdWIthMember(projectId)).thenReturn(Optional.of(mockProject));
-        when(retrospectiveSkillRepository.findTopSkillsByType(projectId, "소프트", PageRequest.of(0, 3)))
+        when(retrospectiveSkillRepository.findTopSkillsByType(projectId, "soft", PageRequest.of(0, 3)))
                 .thenReturn(softSkills);
-        when(retrospectiveSkillRepository.findTopSkillsByType(projectId, "하드", PageRequest.of(0, 3)))
+        when(retrospectiveSkillRepository.findTopSkillsByType(projectId, "hard", PageRequest.of(0, 3)))
                 .thenReturn(hardSkills);
 
 
@@ -299,11 +299,11 @@ class ProjectServiceTest {
         Long projectId = 1L;
         // Mock TaskRetrospectiveSkillDto 리스트
         TaskRetrospectiveSkillDto dto1 = new TaskRetrospectiveSkillDto(1L, LocalDate.now(),
-                LocalDate.now().plusDays(7), null, "소프트", "Communication");
+                LocalDate.now().plusDays(7), null, "soft", "Communication");
         TaskRetrospectiveSkillDto dto2 = new TaskRetrospectiveSkillDto(1L, LocalDate.now(),
-                LocalDate.now().plusDays(7), null, "하드", "Java");
+                LocalDate.now().plusDays(7), null, "hard", "Java");
         TaskRetrospectiveSkillDto dto3 = new TaskRetrospectiveSkillDto(2L,
-                LocalDate.now(), LocalDate.now().plusDays(5), null, "소프트",
+                LocalDate.now(), LocalDate.now().plusDays(5), null, "soft",
                 "Problem Solving");
 
         List<TaskRetrospectiveSkillDto> mockTaskRetrospectives = Arrays.asList(dto1, dto2, dto3);

--- a/src/test/java/com/trekker/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/com/trekker/domain/report/service/ReportServiceTest.java
@@ -83,9 +83,9 @@ class ReportServiceTest {
         LocalDate startOfMonth = LocalDate.of(today.getYear(), today.getMonth(), 1);
         LocalDate endOfMonth = startOfMonth.withDayOfMonth(startOfMonth.lengthOfMonth());
 
-        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, "소프트",
+        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, "soft",
                 PageRequest.of(0, 3))).thenReturn(mockSoftSkillList);
-        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, "하드",
+        when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, "hard",
                 PageRequest.of(0, 3))).thenReturn(mockHardSkillList);
         when(taskRepository.findTasksInMonth(memberId, startOfMonth, endOfMonth)).thenReturn(
                 List.of(task1, task2));
@@ -110,7 +110,7 @@ class ReportServiceTest {
     @Test
     void getMemberSkillList() {
         // given
-        String type = "하드";
+        String type = "hard";
         when(retrospectiveSkillRepository.findTopSkillsByMemberIdAndType(memberId, type, Pageable.unpaged())).thenReturn(
                 mockHardSkillList);
 

--- a/src/test/java/com/trekker/domain/task/application/TaskServiceTest.java
+++ b/src/test/java/com/trekker/domain/task/application/TaskServiceTest.java
@@ -83,7 +83,6 @@ class TaskServiceTest {
     void validateTaskDatesEndDateAfterProjectEnd() {
         // given
         LocalDate projectStartDate = LocalDate.now();
-        LocalDate validStartDate = projectStartDate;
         LocalDate invalidEndDate = projectStartDate.plusDays(10); // 프로젝트 종료일 이후 날짜 설정
         Project project = Project.builder()
                 .id(1L)
@@ -92,7 +91,8 @@ class TaskServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> taskService.validateTaskDatesWithinProject(project, validStartDate, invalidEndDate))
+        assertThatThrownBy(() -> taskService.validateTaskDatesWithinProject(project,
+                projectStartDate, invalidEndDate))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.TASK_BAD_REQUEST.getMessage());
     }

--- a/src/test/java/com/trekker/global/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/trekker/global/auth/application/AuthServiceTest.java
@@ -116,7 +116,7 @@ class AuthServiceTest {
                 .id(1L)
                 .socialProvider(mock(SocialProvider.class))
                 .build();
-        MemberWithdrawalReqDto reqDto = new MemberWithdrawalReqDto("feedback",
+        MemberWithdrawalReqDto reqDto = new MemberWithdrawalReqDto("accessToken", "feedback",
                 "reason");
 
         when(memberRepository.findByIdWithSocialAndOnboarding(id)).thenReturn(Optional.of(member));
@@ -125,7 +125,7 @@ class AuthServiceTest {
         authService.deleteAccount(id, reqDto);
 
         // then
-        verify(unlinkService, times(1)).unlink(member);
+        verify(unlinkService, times(1)).unlink(member, reqDto);
         verify(memberRepository, times(1)).findByIdWithSocialAndOnboarding(id);
         assertThat(member.isDelete()).isTrue();
     }
@@ -135,7 +135,7 @@ class AuthServiceTest {
     void failToDeleteAccountWhenMemberNotFound() {
         // given
         Long nonExistentId = 3L;
-        MemberWithdrawalReqDto reqDto = new MemberWithdrawalReqDto("feedback",
+        MemberWithdrawalReqDto reqDto = new MemberWithdrawalReqDto("accessToken","feedback",
                 "reason");
 
         when(memberRepository.findByIdWithSocialAndOnboarding(nonExistentId)).thenReturn(Optional.empty());
@@ -145,6 +145,6 @@ class AuthServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
         verify(memberRepository, times(1)).findByIdWithSocialAndOnboarding(nonExistentId);
-        verify(unlinkService, never()).unlink(any(Member.class));
+        verify(unlinkService, never()).unlink(any(Member.class),any());
     }
 }


### PR DESCRIPTION
## 🔥 Related Issue
close: #27 

## 📝 Description
구글 로그인 인증 방식을 기존 서버 중심에서 클라이언트 중심으로 변경하였습니다.
- 클라이언트에서 로그인 후 구글의 accessToken과 사용자 정보를 서버로 전달합니다.
- 서버는 이를 이용하여 사용자 회원가입/로그인 후에 자체 토큰 및 온보딩 완료 여부를 반환합니다.

추가적으로 프론트 요청 사항 및 미비된 개발 사항을 구현하였습니다.

## ⭐️ Review